### PR TITLE
Fix: Cache Invalidation for Immediate UI Updates

### DIFF
--- a/frontend/app/dashboard/[id]/page.tsx
+++ b/frontend/app/dashboard/[id]/page.tsx
@@ -63,6 +63,13 @@ export default function WorkoutDetailPage() {
     onSuccess: () => {
       // Invalidate and refetch workout data
       queryClient.invalidateQueries({ queryKey: ['workout', id] });
+      // Invalidate all workout list queries (dashboard, activities page, home page)
+      queryClient.invalidateQueries({ queryKey: ['workouts'] });
+      // Invalidate stats queries
+      queryClient.invalidateQueries({ queryKey: ['weeklyStats'] });
+      queryClient.invalidateQueries({ queryKey: ['yearlyStats'] });
+      queryClient.invalidateQueries({ queryKey: ['yearlyWeeklyStats'] });
+      queryClient.invalidateQueries({ queryKey: ['availablePeriods'] });
       setIsEditingRunType(false);
       setIsEditingNotes(false);
     },
@@ -74,6 +81,11 @@ export default function WorkoutDetailPage() {
       // Invalidate all workout-related queries
       queryClient.invalidateQueries({ queryKey: ['workouts'] });
       queryClient.invalidateQueries({ queryKey: ['workout', id] });
+      // Invalidate stats queries
+      queryClient.invalidateQueries({ queryKey: ['weeklyStats'] });
+      queryClient.invalidateQueries({ queryKey: ['yearlyStats'] });
+      queryClient.invalidateQueries({ queryKey: ['yearlyWeeklyStats'] });
+      queryClient.invalidateQueries({ queryKey: ['availablePeriods'] });
       // Redirect to dashboard
       router.push('/dashboard');
     },

--- a/frontend/components/BulkImport.tsx
+++ b/frontend/components/BulkImport.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { importBulkStravaExport, type BulkImportResponse } from '@/lib/api';
 import { useSettings } from '@/lib/settings';
@@ -10,10 +10,18 @@ export function BulkImport() {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [importResult, setImportResult] = useState<BulkImportResponse | null>(null);
   const { unitPreference } = useSettings();
+  const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: (file: File) => importBulkStravaExport(file, unitPreference),
     onSuccess: (data) => {
+      // Invalidate all workout list queries (dashboard, activities page, home page)
+      queryClient.invalidateQueries({ queryKey: ['workouts'] });
+      // Invalidate stats queries
+      queryClient.invalidateQueries({ queryKey: ['weeklyStats'] });
+      queryClient.invalidateQueries({ queryKey: ['yearlyStats'] });
+      queryClient.invalidateQueries({ queryKey: ['yearlyWeeklyStats'] });
+      queryClient.invalidateQueries({ queryKey: ['availablePeriods'] });
       setImportResult(data);
       setSelectedFile(null);
     },


### PR DESCRIPTION
**Problem:**
Users had to manually refresh the page to see changes after:
- Importing a new activity
- Updating an activity's runType or notes
- Deleting an activity

This caused friction, especially when:
1. Importing an activity and expecting it to appear on the dashboard
2. Updating an activity's runType and filtering by that type on the activities page
3. Viewing stats that didn't reflect recent changes

**Solution:**
Added React Query cache invalidation to all mutations that modify workout data:

1. **Workout Update Mutation** (`dashboard/[id]/page.tsx`):
   - Invalidates workout list queries (`['workouts']`)
   - Invalidates all stats queries

2. **Workout Import Mutations** (`FileUpload.tsx`, `BulkImport.tsx`):
   - Added `useQueryClient` hook
   - Invalidates workout list queries and stats queries on successful import

3. **Workout Delete Mutation** (`dashboard/[id]/page.tsx`):
   - Added stats query invalidations (was already invalidating workout lists)

**Impact:**
- Dashboard shows newly imported activities immediately
- Activities page filter results update immediately after editing runType
- All stats widgets (weekly, yearly, charts) update automatically
- No more manual page refreshes required

**Files Changed:**
- `frontend/app/dashboard/[id]/page.tsx`
- `frontend/components/FileUpload.tsx`
- `frontend/components/BulkImport.tsx`

**Testing:**
1. Import an activity → verify it appears on dashboard immediately
2. Update activity runType → verify it appears in filtered results on activities page immediately
3. Delete an activity → verify it disappears from lists immediately
4. Verify all stats widgets update after any workout change