### PR TITLE
Fix: Invalidate cache after Relative Effort recalculation

### DIFF
--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -161,6 +161,10 @@ export default function SettingsPage() {
       const response = await recalculateAllRelativeEffort();
       setRecalcWorkoutCount(response.totalQualifyingWorkouts);
       setRecalcSuccess(true);
+      
+      // Invalidate all workout queries to refresh the UI
+      invalidateWorkoutQueries(queryClient);
+      
       setTimeout(() => {
         setRecalcSuccess(false);
         setRecalcWorkoutCount(null);
@@ -183,6 +187,10 @@ export default function SettingsPage() {
       const response = await recalculateAllRelativeEffort();
       setRecalcWorkoutCount(response.totalQualifyingWorkouts);
       setRecalcSuccess(true);
+      
+      // Invalidate all workout queries to refresh the UI
+      invalidateWorkoutQueries(queryClient);
+      
       setTimeout(() => {
         setRecalcSuccess(false);
         setRecalcWorkoutCount(null);

--- a/frontend/lib/queryUtils.ts
+++ b/frontend/lib/queryUtils.ts
@@ -25,5 +25,6 @@ export function invalidateWorkoutQueries(queryClient: QueryClient, workoutId?: s
   queryClient.invalidateQueries({ queryKey: ['yearlyStats'] });
   queryClient.invalidateQueries({ queryKey: ['yearlyWeeklyStats'] });
   queryClient.invalidateQueries({ queryKey: ['availablePeriods'] });
+  queryClient.invalidateQueries({ queryKey: ['relativeEffortStats'] });
 }
 


### PR DESCRIPTION
After recalculating Relative Effort values in Settings, the updated values were not appearing on Dashboard and Activities pages until a manual page refresh. This was due to missing React Query cache invalidation.

Changes:
- Add 'relativeEffortStats' query invalidation to invalidateWorkoutQueries() utility function
- Call invalidateWorkoutQueries() after successful recalculation in both handleRecalculateConfirm() and handleZoneUpdateRecalculateAll()

This ensures that:
- Relative Effort graph on Dashboard updates automatically
- Workout cards and Activities table show updated values immediately
- No manual page refresh is required

Fixes bug #19