### PR TITLE
Fix database migration error causing container crash on startup

### DIFF
--- a/api/Migrations/20251122003646_AddUserSettings.cs
+++ b/api/Migrations/20251122003646_AddUserSettings.cs
@@ -11,39 +11,55 @@ namespace Tempo.Api.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.CreateTable(
-                name: "UserSettings",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    Age = table.Column<int>(type: "integer", nullable: true),
-                    MaxHeartRateBpm = table.Column<byte>(type: "smallint", nullable: true),
-                    RestingHeartRateBpm = table.Column<byte>(type: "smallint", nullable: true),
-                    ZoneCalculationMethod = table.Column<int>(type: "integer", nullable: false),
-                    Zone1Min = table.Column<byte>(type: "smallint", nullable: true),
-                    Zone1Max = table.Column<byte>(type: "smallint", nullable: true),
-                    Zone2Min = table.Column<byte>(type: "smallint", nullable: true),
-                    Zone2Max = table.Column<byte>(type: "smallint", nullable: true),
-                    Zone3Min = table.Column<byte>(type: "smallint", nullable: true),
-                    Zone3Max = table.Column<byte>(type: "smallint", nullable: true),
-                    Zone4Min = table.Column<byte>(type: "smallint", nullable: true),
-                    Zone4Max = table.Column<byte>(type: "smallint", nullable: true),
-                    Zone5Min = table.Column<byte>(type: "smallint", nullable: true),
-                    Zone5Max = table.Column<byte>(type: "smallint", nullable: true),
-                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
-                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_UserSettings", x => x.Id);
-                });
+            // Use raw SQL to check if table exists before creating (idempotent migration)
+            migrationBuilder.Sql(@"
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.tables 
+                        WHERE table_schema = 'public' AND table_name = 'UserSettings'
+                    ) THEN
+                        -- Table doesn't exist - create it
+                        CREATE TABLE ""UserSettings"" (
+                            ""Id"" uuid NOT NULL,
+                            ""Age"" integer,
+                            ""MaxHeartRateBpm"" smallint,
+                            ""RestingHeartRateBpm"" smallint,
+                            ""ZoneCalculationMethod"" integer NOT NULL,
+                            ""Zone1Min"" smallint,
+                            ""Zone1Max"" smallint,
+                            ""Zone2Min"" smallint,
+                            ""Zone2Max"" smallint,
+                            ""Zone3Min"" smallint,
+                            ""Zone3Max"" smallint,
+                            ""Zone4Min"" smallint,
+                            ""Zone4Max"" smallint,
+                            ""Zone5Min"" smallint,
+                            ""Zone5Max"" smallint,
+                            ""CreatedAt"" timestamp with time zone NOT NULL,
+                            ""UpdatedAt"" timestamp with time zone NOT NULL,
+                            CONSTRAINT ""PK_UserSettings"" PRIMARY KEY (""Id"")
+                        );
+                    END IF;
+                END $$;
+            ");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable(
-                name: "UserSettings");
+            // Use raw SQL to check if table exists before dropping (idempotent migration)
+            migrationBuilder.Sql(@"
+                DO $$
+                BEGIN
+                    IF EXISTS (
+                        SELECT 1 FROM information_schema.tables 
+                        WHERE table_schema = 'public' AND table_name = 'UserSettings'
+                    ) THEN
+                        DROP TABLE ""UserSettings"";
+                    END IF;
+                END $$;
+            ");
         }
     }
 }

--- a/api/Services/DatabaseMigrationHelper.cs
+++ b/api/Services/DatabaseMigrationHelper.cs
@@ -10,8 +10,24 @@ namespace Tempo.Api.Services;
 /// </summary>
 public static class DatabaseMigrationHelper
 {
+    // Map of table names to their corresponding migration IDs
+    private static readonly Dictionary<string, string> TableToMigrationMap = new()
+    {
+        // InitialCreate migration creates these tables
+        { "Workouts", "20251111150526_InitialCreate" },
+        { "WorkoutRoutes", "20251111150526_InitialCreate" },
+        { "WorkoutSplits", "20251111150526_InitialCreate" },
+        { "WorkoutTimeSeries", "20251111150526_InitialCreate" },
+        { "WorkoutMedia", "20251111150526_InitialCreate" },
+        // AddUserSettings migration
+        { "UserSettings", "20251122003646_AddUserSettings" }
+    };
+
+    private const string ProductVersion = "9.0.10";
+
     /// <summary>
-    /// Applies database migrations, handling edge cases where the database was created with EnsureCreated().
+    /// Applies database migrations, handling edge cases where the database was created with EnsureCreated()
+    /// or has tables that exist but aren't recorded in migration history.
     /// </summary>
     public static void ApplyMigrations(TempoDbContext db)
     {
@@ -28,22 +44,8 @@ public static class DatabaseMigrationHelper
                 );
             ");
             
-            // Check if Workouts table exists (indicates InitialCreate was applied via EnsureCreated)
-            var workoutsTableExists = CheckWorkoutsTableExists(db);
-            
-            // Check if InitialCreate migration is recorded
-            var initialCreateRecorded = CheckInitialCreateRecorded(db);
-            
-            // If tables exist but InitialCreate isn't recorded, mark it as applied
-            if (workoutsTableExists && !initialCreateRecorded)
-            {
-                db.Database.ExecuteSqlRaw(@"
-                    INSERT INTO ""__EFMigrationsHistory"" (""MigrationId"", ""ProductVersion"") 
-                    VALUES ('20251110232429_InitialCreate', '9.0.10')
-                    ON CONFLICT (""MigrationId"") DO NOTHING;
-                ");
-                Log.Information("Marked InitialCreate migration as applied (tables existed from EnsureCreated)");
-            }
+            // Detect all existing tables and mark corresponding migrations as applied
+            SyncMigrationHistory(db);
         }
         catch (Exception ex)
         {
@@ -51,52 +53,143 @@ public static class DatabaseMigrationHelper
         }
         
         // Now apply any pending migrations
-        db.Database.Migrate();
-        Log.Information("Database migrations applied successfully");
+        try
+        {
+            db.Database.Migrate();
+            Log.Information("Database migrations applied successfully");
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to apply database migrations");
+            throw; // Re-throw to prevent app from starting with broken database state
+        }
     }
 
-    private static bool CheckWorkoutsTableExists(TempoDbContext db)
+    /// <summary>
+    /// Synchronizes migration history by detecting existing tables and marking their migrations as applied.
+    /// </summary>
+    private static void SyncMigrationHistory(TempoDbContext db)
     {
         try
         {
             var connection = db.Database.GetDbConnection();
             if (connection.State != ConnectionState.Open)
                 connection.Open();
+
+            // Get all existing tables in the public schema
+            var existingTables = GetExistingTables(db);
+            Log.Information("Found {Count} existing tables in database", existingTables.Count);
+
+            // Get all recorded migrations
+            var recordedMigrations = GetRecordedMigrations(db);
+            Log.Information("Found {Count} recorded migrations in history", recordedMigrations.Count);
+
+            // Determine which migrations should be marked as applied based on existing tables
+            var migrationsToMark = new HashSet<string>();
             
-            using var command = connection.CreateCommand();
-            command.CommandText = @"
-                SELECT COUNT(*) FROM information_schema.tables 
-                WHERE table_schema = 'public' AND table_name = 'Workouts';
-            ";
-            var result = command.ExecuteScalar();
-            return Convert.ToInt32(result) > 0;
+            foreach (var table in existingTables)
+            {
+                if (TableToMigrationMap.TryGetValue(table, out var migrationId))
+                {
+                    if (!recordedMigrations.Contains(migrationId))
+                    {
+                        migrationsToMark.Add(migrationId);
+                        Log.Information("Table '{Table}' exists but migration '{Migration}' is not recorded", table, migrationId);
+                    }
+                }
+            }
+
+            // Mark missing migrations as applied
+            foreach (var migrationId in migrationsToMark)
+            {
+                try
+                {
+                    db.Database.ExecuteSqlRaw(@"
+                        INSERT INTO ""__EFMigrationsHistory"" (""MigrationId"", ""ProductVersion"") 
+                        VALUES ({0}, {1})
+                        ON CONFLICT (""MigrationId"") DO NOTHING;
+                    ", migrationId, ProductVersion);
+                    Log.Information("Marked migration '{Migration}' as applied (table already exists)", migrationId);
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "Failed to mark migration '{Migration}' as applied", migrationId);
+                }
+            }
         }
-        catch
+        catch (Exception ex)
         {
-            return false;
+            Log.Warning(ex, "Error synchronizing migration history - will attempt to migrate anyway");
         }
     }
 
-    private static bool CheckInitialCreateRecorded(TempoDbContext db)
+    /// <summary>
+    /// Gets a list of all existing tables in the public schema.
+    /// </summary>
+    private static List<string> GetExistingTables(TempoDbContext db)
     {
+        var tables = new List<string>();
         try
         {
             var connection = db.Database.GetDbConnection();
             if (connection.State != ConnectionState.Open)
                 connection.Open();
-            
+
             using var command = connection.CreateCommand();
             command.CommandText = @"
-                SELECT COUNT(*) FROM ""__EFMigrationsHistory""
-                WHERE ""MigrationId"" = '20251110232429_InitialCreate';
+                SELECT table_name 
+                FROM information_schema.tables 
+                WHERE table_schema = 'public' 
+                AND table_type = 'BASE TABLE'
+                ORDER BY table_name;
             ";
-            var result = command.ExecuteScalar();
-            return Convert.ToInt32(result) > 0;
+
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                var tableName = reader.GetString(0);
+                tables.Add(tableName);
+            }
         }
-        catch
+        catch (Exception ex)
         {
-            return false;
+            Log.Warning(ex, "Error getting existing tables");
         }
+
+        return tables;
+    }
+
+    /// <summary>
+    /// Gets a set of all migration IDs that are recorded in the migration history.
+    /// </summary>
+    private static HashSet<string> GetRecordedMigrations(TempoDbContext db)
+    {
+        var migrations = new HashSet<string>();
+        try
+        {
+            var connection = db.Database.GetDbConnection();
+            if (connection.State != ConnectionState.Open)
+                connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = @"
+                SELECT ""MigrationId"" 
+                FROM ""__EFMigrationsHistory"";
+            ";
+
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                var migrationId = reader.GetString(0);
+                migrations.Add(migrationId);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Error getting recorded migrations");
+        }
+
+        return migrations;
     }
 }
 


### PR DESCRIPTION
Fixed issue where tempo-api container was crashing with exit code 139 due to migration error: 'relation UserSettings already exists'.

Changes:
- Enhanced DatabaseMigrationHelper to detect existing tables and automatically sync migration history by marking corresponding migrations as applied
- Made AddUserSettings migration idempotent by checking table existence before creating (prevents 'already exists' errors)
- Added comprehensive error handling and logging in Program.cs to provide better diagnostics when migrations fail
- Fixed incorrect migration ID reference in DatabaseMigrationHelper (20251110232429 -> 20251111150526)

The migration helper now detects all existing tables (Workouts, UserSettings, WorkoutRoutes, etc.) and ensures their migrations are properly recorded in __EFMigrationsHistory before attempting to apply new migrations. This prevents conflicts when the database has tables that exist but aren't recorded in migration history.

Fixes container startup failure in production deployments.