### PR TITLE
feat: Add activity name editing functionality

### DIFF
--- a/frontend/components/WorkoutDetailHeader.tsx
+++ b/frontend/components/WorkoutDetailHeader.tsx
@@ -10,7 +10,9 @@ interface WorkoutDetailHeaderProps {
 
 export default function WorkoutDetailHeader({ workout }: WorkoutDetailHeaderProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const { deleteWorkoutMutation, handleDeleteWorkout } = useWorkoutMutations(workout.id);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [nameValue, setNameValue] = useState<string>('');
+  const { deleteWorkoutMutation, handleDeleteWorkout, updateWorkoutMutation } = useWorkoutMutations(workout.id);
 
   // Close menu when clicking outside
   useEffect(() => {
@@ -29,12 +31,105 @@ export default function WorkoutDetailHeader({ workout }: WorkoutDetailHeaderProp
     }
   }, [isMenuOpen]);
 
+  // Sync nameValue with workout.name when entering edit mode or data changes
+  useEffect(() => {
+    if (workout && isEditingName) {
+      setNameValue(workout.name || '');
+    }
+  }, [workout, isEditingName]);
+
+  const handleSaveName = () => {
+    const trimmedName = nameValue.trim() || null;
+    updateWorkoutMutation.mutate(
+      { name: trimmedName },
+      {
+        onSuccess: () => {
+          setIsEditingName(false);
+        },
+      }
+    );
+  };
+
+  const handleCancelName = () => {
+    setIsEditingName(false);
+    setNameValue(workout.name || '');
+  };
+
   return (
     <div className="w-full mb-4">
       <div className="flex items-center gap-2 mb-1" data-menu-container>
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
-          {getWorkoutDisplayName(workout.name, workout.startedAt)}
-        </h1>
+        {isEditingName ? (
+          <div className="flex-1 flex items-center gap-2">
+            <input
+              type="text"
+              value={nameValue}
+              onChange={(e) => setNameValue(e.target.value)}
+              disabled={updateWorkoutMutation.isPending}
+              placeholder="Enter activity name..."
+              maxLength={200}
+              className="flex-1 px-3 py-2 text-3xl font-bold border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  handleSaveName();
+                } else if (e.key === 'Escape') {
+                  handleCancelName();
+                }
+              }}
+            />
+            <button
+              onClick={handleSaveName}
+              disabled={updateWorkoutMutation.isPending}
+              className="px-3 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 rounded-md disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              type="button"
+            >
+              Save
+            </button>
+            <button
+              onClick={handleCancelName}
+              disabled={updateWorkoutMutation.isPending}
+              className="px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-md disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              type="button"
+            >
+              Cancel
+            </button>
+            {updateWorkoutMutation.isPending && (
+              <span className="text-sm text-gray-500 dark:text-gray-400">Saving...</span>
+            )}
+            {updateWorkoutMutation.isError && (
+              <span className="text-sm text-red-600 dark:text-red-400">
+                Error: {updateWorkoutMutation.error instanceof Error ? updateWorkoutMutation.error.message : 'Failed to update'}
+              </span>
+            )}
+          </div>
+        ) : (
+          <button
+            onClick={() => {
+              setNameValue(workout.name || '');
+              setIsEditingName(true);
+            }}
+            className="flex items-center gap-2 group hover:text-blue-600 dark:hover:text-blue-400 transition-colors text-left"
+            type="button"
+          >
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 group-hover:text-blue-600 dark:group-hover:text-blue-400">
+              {getWorkoutDisplayName(workout.name, workout.startedAt)}
+            </h1>
+            <svg
+              className="w-5 h-5 opacity-0 group-hover:opacity-50 flex-shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+              />
+            </svg>
+          </button>
+        )}
         <div className="relative">
           <button
             onClick={() => setIsMenuOpen(!isMenuOpen)}

--- a/frontend/hooks/useWorkoutMutations.ts
+++ b/frontend/hooks/useWorkoutMutations.ts
@@ -8,7 +8,7 @@ export function useWorkoutMutations(workoutId: string) {
   const queryClient = useQueryClient();
 
   const updateWorkoutMutation = useMutation({
-    mutationFn: (updates: { runType?: string | null; notes?: string | null }) =>
+    mutationFn: (updates: { runType?: string | null; notes?: string | null; name?: string | null }) =>
       updateWorkout(workoutId, updates),
     onSuccess: () => {
       invalidateWorkoutQueries(queryClient, workoutId);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -545,12 +545,14 @@ export async function getAvailableYears(): Promise<number[]> {
 export interface UpdateWorkoutRequest {
   runType?: string | null;
   notes?: string | null;
+  name?: string | null;
 }
 
 export interface UpdateWorkoutResponse {
   id: string;
   runType: string | null;
   notes: string | null;
+  name: string | null;
 }
 
 export async function updateWorkout(


### PR DESCRIPTION
Enable users to edit activity names through inline editing in the workout detail header, following the same pattern as notes/runType editing.

- Backend: Update PATCH endpoint to accept and validate name field
- Frontend: Add name to update interfaces and implement inline editing UI with keyboard shortcuts and proper state management
- Query invalidation ensures all views refresh after updates