### PR TITLE
feat(workouts): add workout crop/trim functionality

### DIFF
--- a/WorkoutCropFeature.md
+++ b/WorkoutCropFeature.md
@@ -1,0 +1,125 @@
+## User Story
+
+**As a** runner who participates in races
+**I want to** crop/trim the beginning or end of my workout
+**So that** my recorded workout time matches the official race time
+
+### Acceptance Criteria
+
+1. **User can access crop functionality** from the workout detail page
+2. **Interactive timeline interface** allows users to visually select start and end points
+3. **Preview shows** the new duration and distance before applying
+4. **Crop operation updates**:
+
+- Workout `StartedAt` timestamp (if trimming start)
+- Workout `DurationS` (reduced by trimmed time)
+- Workout `DistanceM` (recalculated from cropped route)
+- All aggregated stats (pace, elevation, heart rate averages, etc.)
+- Time series data (remove points outside range, reindex `ElapsedSeconds` from 0)
+- Route coordinates (remove points outside range)
+- Splits (recalculated from cropped data)
+
+5. **Original raw data preserved** (RawGpxData, RawFitData, RawFileData) for audit trail
+6. **Relative Effort recalculated** after crop if heart rate zones are configured
+7. **User can undo** the crop operation (restore from original data)
+
+### Technical Viability Assessment
+
+**✅ Highly Viable** - The codebase architecture supports this feature well:
+
+#### Strengths
+
+1. **Data Model Supports Cropping**:
+
+- `WorkoutTimeSeries` uses `ElapsedSeconds` (relative to start) - easy to filter and reindex
+- Route stored as GeoJSON LineString - can trim coordinate arrays
+- Splits are recalculated from track points (existing `SplitRecalculationService` pattern)
+- Raw data stored separately - can preserve original
+
+2. **Existing Patterns to Follow**:
+
+- `SplitRecalculationService` demonstrates recalculating derived data
+- `RelativeEffortService` shows how to work with time series data
+- PATCH endpoint pattern exists for workout updates
+- Recalculation endpoints exist (`/recalculate-splits`, `/recalculate-effort`)
+
+3. **Data Integrity**:
+
+- Time series has composite index on `(WorkoutId, ElapsedSeconds)` for efficient queries
+- Cascade deletes configured for related data
+- Raw data preservation maintains audit trail
+
+#### Implementation Considerations
+
+1. **Backend Service** (`WorkoutCropService.cs`):
+
+- Filter time series by `ElapsedSeconds` range
+- Reindex remaining time series points (subtract trim start from `ElapsedSeconds`)
+- Trim route GeoJSON coordinates array
+- Recalculate workout aggregates (distance, pace, elevation, HR stats)
+- Update `StartedAt` if trimming start
+- Update `DurationS`
+- Trigger split recalculation
+- Trigger relative effort recalculation
+
+2. **API Endpoint** (`POST /workouts/{id}/crop`):
+
+- Accept `startTrimSeconds` and `endTrimSeconds` parameters
+- Validate trim values don't exceed workout duration
+- Call `WorkoutCropService`
+- Return updated workout data
+
+3. **Frontend Components**:
+
+- `CropWorkoutDialog.tsx` - Modal with interactive timeline
+- Timeline slider component (similar to video editor)
+- Preview showing new duration/distance
+- Confirmation before applying
+
+4. **Edge Cases**:
+
+- Workouts without time series data (fallback to route coordinates)
+- Workouts without route data (cannot crop)
+- Very short workouts (minimum duration validation)
+- Cropping entire workout (should be prevented)
+
+#### Potential Challenges
+
+1. **Time Series Data Volume**: Large workouts may have thousands of time series points - batch deletion/update operations needed
+2. **Route Coordinate Mapping**: Need to map time-based crop to coordinate indices (may require interpolation)
+3. **Split Recalculation**: Must ensure splits recalculate correctly with cropped data
+4. **UI Complexity**: Interactive timeline slider requires careful UX design
+
+#### Estimated Complexity
+
+- **Backend**: Medium (new service + endpoint, similar to existing recalculation services)
+- **Frontend**: Medium-High (interactive timeline UI is more complex)
+- **Testing**: Medium (need to test various crop scenarios, edge cases)
+
+### Recommended Implementation Approach
+
+1. **Phase 1**: Basic time-based cropping (specify seconds to trim)
+2. **Phase 2**: Add interactive timeline UI
+3. **Phase 3**: Add undo/restore functionality
+
+### Files to Modify/Create
+
+**Backend:**
+
+- `api/Services/WorkoutCropService.cs` (new)
+- `api/Endpoints/WorkoutsEndpoints.cs` (add crop endpoint)
+- `api/Models/Workout.cs` (may need to track original duration for undo)
+
+**Frontend:**
+
+- `frontend/components/CropWorkoutDialog.tsx` (new)
+- `frontend/components/WorkoutDetailHeader.tsx` (add crop button)
+- `frontend/lib/api.ts` (add crop API function)
+- `frontend/hooks/useWorkoutMutations.ts` (add crop mutation)
+
+### Success Metrics
+
+- Users can successfully crop workouts to match race times
+- Cropped workouts maintain data integrity (splits, stats recalculate correctly)
+- Original data preserved for audit trail
+- No performance issues with large workouts

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -48,6 +48,7 @@ builder.Services.AddScoped<HeartRateZoneService>();
 builder.Services.AddScoped<RelativeEffortService>();
 builder.Services.AddScoped<BulkImportService>();
 builder.Services.AddScoped<SplitRecalculationService>();
+builder.Services.AddScoped<WorkoutCropService>();
 builder.Services.AddHttpClient<WeatherService>();
 
 // Configure media storage

--- a/api/Services/WorkoutCropService.cs
+++ b/api/Services/WorkoutCropService.cs
@@ -1,0 +1,458 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Tempo.Api.Data;
+using Tempo.Api.Models;
+using Tempo.Api.Utils;
+
+namespace Tempo.Api.Services;
+
+/// <summary>
+/// Service for cropping/trimming workouts by removing time from the beginning or end.
+/// </summary>
+public class WorkoutCropService
+{
+    private readonly TempoDbContext _db;
+    private readonly ILogger<WorkoutCropService> _logger;
+    private const int MinimumRemainingDurationSeconds = 10;
+
+    public WorkoutCropService(
+        TempoDbContext db,
+        ILogger<WorkoutCropService> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Crops a workout by removing time from the beginning and/or end.
+    /// </summary>
+    public async Task<Workout> CropWorkoutAsync(
+        Workout workout,
+        int startTrimSeconds,
+        int endTrimSeconds)
+    {
+        if (workout.Route == null)
+        {
+            throw new InvalidOperationException("Workout has no route data. Cannot crop workout without route.");
+        }
+
+        var originalDurationS = workout.DurationS;
+        var newDurationS = originalDurationS - startTrimSeconds - endTrimSeconds;
+
+        if (newDurationS < MinimumRemainingDurationSeconds)
+        {
+            throw new InvalidOperationException(
+                $"Cropping would result in a workout shorter than {MinimumRemainingDurationSeconds} seconds. " +
+                $"Original duration: {originalDurationS}s, Trim: {startTrimSeconds}s start + {endTrimSeconds}s end = {startTrimSeconds + endTrimSeconds}s");
+        }
+
+        _logger.LogInformation(
+            "Cropping workout {WorkoutId}: Original duration {OriginalDuration}s, " +
+            "Trimming {StartTrim}s from start and {EndTrim}s from end, " +
+            "New duration: {NewDuration}s",
+            workout.Id, originalDurationS, startTrimSeconds, endTrimSeconds, newDurationS);
+
+        // Load time series data
+        var timeSeries = await _db.WorkoutTimeSeries
+            .Where(ts => ts.WorkoutId == workout.Id)
+            .OrderBy(ts => ts.ElapsedSeconds)
+            .ToListAsync();
+
+        // Filter and reindex time series
+        var croppedTimeSeries = await CropTimeSeriesAsync(
+            workout.Id,
+            timeSeries,
+            startTrimSeconds,
+            endTrimSeconds,
+            originalDurationS);
+
+        // Trim route coordinates
+        var croppedRoute = CropRoute(workout.Route, timeSeries, startTrimSeconds, endTrimSeconds, originalDurationS);
+
+        // Recalculate aggregates from cropped data
+        RecalculateAggregates(workout, croppedTimeSeries, croppedRoute, startTrimSeconds, newDurationS);
+
+        // Update workout fields
+        workout.DurationS = newDurationS;
+        workout.StartedAt = workout.StartedAt.AddSeconds(startTrimSeconds);
+        workout.AvgPaceS = newDurationS > 0 && workout.DistanceM > 0
+            ? (int)(newDurationS / (workout.DistanceM / 1000.0))
+            : 0;
+
+        // Update route
+        workout.Route.RouteGeoJson = croppedRoute;
+
+        // Delete old time series and add new ones
+        if (timeSeries.Count > 0)
+        {
+            _db.WorkoutTimeSeries.RemoveRange(timeSeries);
+        }
+        if (croppedTimeSeries.Count > 0)
+        {
+            _db.WorkoutTimeSeries.AddRange(croppedTimeSeries);
+        }
+
+        await _db.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "Successfully cropped workout {WorkoutId}: Duration {NewDuration}s, Distance {Distance}m",
+            workout.Id, newDurationS, workout.DistanceM);
+
+        return workout;
+    }
+
+    /// <summary>
+    /// Filters and reindexes time series data based on crop parameters.
+    /// </summary>
+    private async Task<List<WorkoutTimeSeries>> CropTimeSeriesAsync(
+        Guid workoutId,
+        List<WorkoutTimeSeries> timeSeries,
+        int startTrimSeconds,
+        int endTrimSeconds,
+        int originalDurationS)
+    {
+        var endTimeThreshold = originalDurationS - endTrimSeconds;
+
+        var cropped = timeSeries
+            .Where(ts => ts.ElapsedSeconds >= startTrimSeconds && ts.ElapsedSeconds <= endTimeThreshold)
+            .Select(ts => new WorkoutTimeSeries
+            {
+                Id = Guid.NewGuid(),
+                WorkoutId = workoutId,
+                ElapsedSeconds = ts.ElapsedSeconds - startTrimSeconds,
+                DistanceM = ts.DistanceM.HasValue && timeSeries.Count > 0
+                    ? CalculateCroppedDistance(ts.DistanceM.Value, timeSeries, startTrimSeconds)
+                    : ts.DistanceM,
+                HeartRateBpm = ts.HeartRateBpm,
+                CadenceRpm = ts.CadenceRpm,
+                PowerWatts = ts.PowerWatts,
+                SpeedMps = ts.SpeedMps,
+                GradePercent = ts.GradePercent,
+                ElevationM = ts.ElevationM,
+                TemperatureC = ts.TemperatureC,
+                VerticalSpeedMps = ts.VerticalSpeedMps
+            })
+            .ToList();
+
+        return cropped;
+    }
+
+    /// <summary>
+    /// Calculates the cropped distance by subtracting the distance at the start trim point.
+    /// </summary>
+    private double? CalculateCroppedDistance(
+        double distanceAtPoint,
+        List<WorkoutTimeSeries> timeSeries,
+        int startTrimSeconds)
+    {
+        // Find the distance at the start trim point (or closest point before it)
+        var startPoint = timeSeries
+            .Where(ts => ts.ElapsedSeconds <= startTrimSeconds && ts.DistanceM.HasValue)
+            .OrderByDescending(ts => ts.ElapsedSeconds)
+            .FirstOrDefault();
+
+        if (startPoint?.DistanceM.HasValue == true)
+        {
+            var startDistance = startPoint.DistanceM.Value;
+            return Math.Max(0, distanceAtPoint - startDistance);
+        }
+
+        // If we can't find a start point, return null (will be recalculated from route)
+        return null;
+    }
+
+    /// <summary>
+    /// Trims route coordinates based on crop parameters.
+    /// </summary>
+    private string CropRoute(
+        WorkoutRoute route,
+        List<WorkoutTimeSeries> timeSeries,
+        int startTrimSeconds,
+        int endTrimSeconds,
+        int originalDurationS)
+    {
+        try
+        {
+            var geoJson = JsonSerializer.Deserialize<JsonElement>(route.RouteGeoJson);
+            if (!geoJson.TryGetProperty("coordinates", out var coordinatesElement))
+            {
+                throw new InvalidOperationException("Route GeoJSON does not contain coordinates");
+            }
+
+            var coordinates = coordinatesElement.EnumerateArray().ToList();
+            if (coordinates.Count == 0)
+            {
+                return route.RouteGeoJson;
+            }
+
+            // Determine start and end indices for cropping
+            int startIndex = 0;
+            int endIndex = coordinates.Count - 1;
+
+            if (timeSeries.Count > 0)
+            {
+                // Map time-based crop to coordinate indices using time series
+                startIndex = FindCoordinateIndexFromTime(timeSeries, startTrimSeconds, coordinates.Count);
+                endIndex = FindCoordinateIndexFromTime(timeSeries, originalDurationS - endTrimSeconds, coordinates.Count);
+            }
+            else
+            {
+                // No time series: estimate based on time ratio
+                var startRatio = (double)startTrimSeconds / originalDurationS;
+                var endRatio = (double)(originalDurationS - endTrimSeconds) / originalDurationS;
+                startIndex = (int)Math.Floor(startRatio * coordinates.Count);
+                endIndex = (int)Math.Ceiling(endRatio * coordinates.Count) - 1;
+            }
+
+            // Ensure valid indices
+            startIndex = Math.Max(0, Math.Min(startIndex, coordinates.Count - 1));
+            endIndex = Math.Max(startIndex, Math.Min(endIndex, coordinates.Count - 1));
+
+            // Extract cropped coordinates
+            var croppedCoordinates = new List<JsonElement>();
+            for (int i = startIndex; i <= endIndex; i++)
+            {
+                croppedCoordinates.Add(coordinates[i]);
+            }
+
+            // Rebuild GeoJSON
+            var croppedGeoJson = new
+            {
+                type = "LineString",
+                coordinates = croppedCoordinates.Select(c => c.EnumerateArray().Select(e => e.GetDouble()).ToArray()).ToArray()
+            };
+
+            return JsonSerializer.Serialize(croppedGeoJson);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to crop route coordinates, returning original route");
+            return route.RouteGeoJson;
+        }
+    }
+
+    /// <summary>
+    /// Finds the coordinate index corresponding to a specific elapsed time.
+    /// </summary>
+    private int FindCoordinateIndexFromTime(
+        List<WorkoutTimeSeries> timeSeries,
+        int targetElapsedSeconds,
+        int totalCoordinates)
+    {
+        // Find the time series point closest to the target time
+        var closestPoint = timeSeries
+            .OrderBy(ts => Math.Abs(ts.ElapsedSeconds - targetElapsedSeconds))
+            .FirstOrDefault();
+
+        if (closestPoint == null)
+        {
+            // Fallback: estimate based on time ratio
+            var timeRatio = (double)targetElapsedSeconds / (timeSeries.LastOrDefault()?.ElapsedSeconds ?? 1);
+            return (int)Math.Floor(timeRatio * totalCoordinates);
+        }
+
+        // Map time series index to coordinate index
+        var timeSeriesIndex = timeSeries.IndexOf(closestPoint);
+        var indexRatio = (double)timeSeriesIndex / timeSeries.Count;
+        return (int)Math.Floor(indexRatio * totalCoordinates);
+    }
+
+    /// <summary>
+    /// Recalculates workout aggregates from cropped time series and route data.
+    /// </summary>
+    private void RecalculateAggregates(
+        Workout workout,
+        List<WorkoutTimeSeries> croppedTimeSeries,
+        string croppedRouteJson,
+        int startTrimSeconds,
+        int newDurationS)
+    {
+        // Recalculate distance from route
+        try
+        {
+            var geoJson = JsonSerializer.Deserialize<JsonElement>(croppedRouteJson);
+            if (geoJson.TryGetProperty("coordinates", out var coordinatesElement))
+            {
+                var coordinates = coordinatesElement.EnumerateArray().ToList();
+                double totalDistance = 0.0;
+
+                for (int i = 1; i < coordinates.Count; i++)
+                {
+                    var prevCoord = coordinates[i - 1].EnumerateArray().ToArray();
+                    var currCoord = coordinates[i].EnumerateArray().ToArray();
+
+                    if (prevCoord.Length >= 2 && currCoord.Length >= 2)
+                    {
+                        var distance = GeoUtils.HaversineDistance(
+                            prevCoord[1].GetDouble(), // latitude
+                            prevCoord[0].GetDouble(), // longitude
+                            currCoord[1].GetDouble(),
+                            currCoord[0].GetDouble()
+                        );
+                        totalDistance += distance;
+                    }
+                }
+
+                workout.DistanceM = totalDistance;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to recalculate distance from route, using time series data");
+        }
+
+        // If we have time series data, use it for distance and other metrics
+        if (croppedTimeSeries.Count > 0)
+        {
+            var lastPoint = croppedTimeSeries.LastOrDefault(ts => ts.DistanceM.HasValue);
+            if (lastPoint?.DistanceM.HasValue == true)
+            {
+                workout.DistanceM = lastPoint.DistanceM.Value;
+            }
+
+            // Recalculate heart rate stats
+            var heartRates = croppedTimeSeries
+                .Where(ts => ts.HeartRateBpm.HasValue)
+                .Select(ts => (int)ts.HeartRateBpm!.Value)
+                .ToList();
+
+            if (heartRates.Count > 0)
+            {
+                workout.MaxHeartRateBpm = (byte)heartRates.Max();
+                workout.MinHeartRateBpm = (byte)heartRates.Min();
+                workout.AvgHeartRateBpm = (byte)Math.Round(heartRates.Average());
+            }
+
+            // Recalculate cadence stats
+            var cadences = croppedTimeSeries
+                .Where(ts => ts.CadenceRpm.HasValue)
+                .Select(ts => (int)ts.CadenceRpm!.Value)
+                .ToList();
+
+            if (cadences.Count > 0)
+            {
+                workout.MaxCadenceRpm = (byte)cadences.Max();
+                workout.AvgCadenceRpm = (byte)Math.Round(cadences.Average());
+            }
+
+            // Recalculate power stats
+            var powers = croppedTimeSeries
+                .Where(ts => ts.PowerWatts.HasValue)
+                .Select(ts => (int)ts.PowerWatts!.Value)
+                .ToList();
+
+            if (powers.Count > 0)
+            {
+                workout.MaxPowerWatts = (ushort)powers.Max();
+                workout.AvgPowerWatts = (ushort)Math.Round(powers.Average());
+            }
+
+            // Recalculate speed stats
+            var speeds = croppedTimeSeries
+                .Where(ts => ts.SpeedMps.HasValue)
+                .Select(ts => ts.SpeedMps!.Value)
+                .ToList();
+
+            if (speeds.Count > 0)
+            {
+                workout.MaxSpeedMps = speeds.Max();
+                workout.AvgSpeedMps = speeds.Average();
+            }
+
+            // Recalculate elevation stats
+            var elevations = croppedTimeSeries
+                .Where(ts => ts.ElevationM.HasValue)
+                .Select(ts => ts.ElevationM!.Value)
+                .ToList();
+
+            if (elevations.Count > 0)
+            {
+                workout.MinElevM = elevations.Min();
+                workout.MaxElevM = elevations.Max();
+
+                // Calculate elevation gain/loss from cropped data
+                double elevationGain = 0.0;
+                double elevationLoss = 0.0;
+                double? lastElevation = null;
+
+                foreach (var elevation in elevations)
+                {
+                    if (lastElevation.HasValue)
+                    {
+                        var diff = elevation - lastElevation.Value;
+                        if (diff > 0)
+                        {
+                            elevationGain += diff;
+                        }
+                        else if (diff < 0)
+                        {
+                            elevationLoss += Math.Abs(diff);
+                        }
+                    }
+                    lastElevation = elevation;
+                }
+
+                workout.ElevGainM = elevationGain > 0 ? elevationGain : null;
+                workout.ElevLossM = elevationLoss > 0 ? elevationLoss : null;
+            }
+        }
+        else
+        {
+            // No time series: try to recalculate elevation from route
+            try
+            {
+                var geoJson = JsonSerializer.Deserialize<JsonElement>(croppedRouteJson);
+                if (geoJson.TryGetProperty("coordinates", out var coordinatesElement))
+                {
+                    var coordinates = coordinatesElement.EnumerateArray().ToList();
+                    var elevations = new List<double>();
+
+                    foreach (var coord in coordinates)
+                    {
+                        var coordArray = coord.EnumerateArray().ToArray();
+                        if (coordArray.Length >= 3)
+                        {
+                            elevations.Add(coordArray[2].GetDouble());
+                        }
+                    }
+
+                    if (elevations.Count > 0)
+                    {
+                        workout.MinElevM = elevations.Min();
+                        workout.MaxElevM = elevations.Max();
+
+                        // Simple elevation gain/loss calculation
+                        double elevationGain = 0.0;
+                        double elevationLoss = 0.0;
+                        double? lastElevation = null;
+
+                        foreach (var elevation in elevations)
+                        {
+                            if (lastElevation.HasValue)
+                            {
+                                var diff = elevation - lastElevation.Value;
+                                if (diff > 0)
+                                {
+                                    elevationGain += diff;
+                                }
+                                else if (diff < 0)
+                                {
+                                    elevationLoss += Math.Abs(diff);
+                                }
+                            }
+                            lastElevation = elevation;
+                        }
+
+                        workout.ElevGainM = elevationGain > 0 ? elevationGain : null;
+                        workout.ElevLossM = elevationLoss > 0 ? elevationLoss : null;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to recalculate elevation from route");
+            }
+        }
+    }
+}
+

--- a/frontend/components/CropWorkoutDialog.tsx
+++ b/frontend/components/CropWorkoutDialog.tsx
@@ -1,0 +1,352 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { formatDuration, formatDistance } from '@/lib/format';
+import type { WorkoutDetail } from '@/lib/api';
+import { useSettings } from '@/lib/settings';
+
+interface CropWorkoutDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (startTrimSeconds: number, endTrimSeconds: number) => void;
+  workout: WorkoutDetail;
+  isLoading?: boolean;
+}
+
+const MINIMUM_REMAINING_DURATION_SECONDS = 10;
+
+/**
+ * Converts MM:SS format to seconds
+ */
+function parseTimeString(timeStr: string): number | null {
+  const parts = timeStr.split(':');
+  if (parts.length === 2) {
+    const minutes = parseInt(parts[0], 10);
+    const seconds = parseInt(parts[1], 10);
+    if (!isNaN(minutes) && !isNaN(seconds) && minutes >= 0 && seconds >= 0 && seconds < 60) {
+      return minutes * 60 + seconds;
+    }
+  }
+  return null;
+}
+
+/**
+ * Converts seconds to MM:SS format
+ */
+function formatTimeString(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+export function CropWorkoutDialog({
+  open,
+  onClose,
+  onConfirm,
+  workout,
+  isLoading = false,
+}: CropWorkoutDialogProps) {
+  const { unitPreference } = useSettings();
+  const [startTrimSeconds, setStartTrimSeconds] = useState(0);
+  const [endTrimSeconds, setEndTrimSeconds] = useState(0);
+  const [startTrimInput, setStartTrimInput] = useState('0:00');
+  const [endTrimInput, setEndTrimInput] = useState('0:00');
+
+  const originalDurationS = workout.durationS;
+  const originalDistanceM = workout.distanceM;
+
+  // Calculate new values
+  const newDurationS = Math.max(0, originalDurationS - startTrimSeconds - endTrimSeconds);
+  const newDistanceM = originalDistanceM * (newDurationS / originalDurationS); // Estimate based on time ratio
+
+  // Validation
+  const isValid = newDurationS >= MINIMUM_REMAINING_DURATION_SECONDS &&
+    startTrimSeconds >= 0 &&
+    endTrimSeconds >= 0 &&
+    startTrimSeconds + endTrimSeconds < originalDurationS;
+
+  // Update input strings when slider values change
+  useEffect(() => {
+    setStartTrimInput(formatTimeString(startTrimSeconds));
+  }, [startTrimSeconds]);
+
+  useEffect(() => {
+    setEndTrimInput(formatTimeString(endTrimSeconds));
+  }, [endTrimSeconds]);
+
+  const handleStartTrimInputChange = (value: string) => {
+    setStartTrimInput(value);
+    const seconds = parseTimeString(value);
+    if (seconds !== null && seconds >= 0 && seconds <= originalDurationS - endTrimSeconds - MINIMUM_REMAINING_DURATION_SECONDS) {
+      setStartTrimSeconds(seconds);
+    }
+  };
+
+  const handleEndTrimInputChange = (value: string) => {
+    setEndTrimInput(value);
+    const seconds = parseTimeString(value);
+    if (seconds !== null && seconds >= 0 && seconds <= originalDurationS - startTrimSeconds - MINIMUM_REMAINING_DURATION_SECONDS) {
+      setEndTrimSeconds(seconds);
+    }
+  };
+
+  const handleStartSliderChange = (value: number) => {
+    const maxStartTrim = originalDurationS - endTrimSeconds - MINIMUM_REMAINING_DURATION_SECONDS;
+    const newStartTrim = Math.max(0, Math.min(value, maxStartTrim));
+    setStartTrimSeconds(newStartTrim);
+  };
+
+  const handleEndSliderChange = (value: number) => {
+    const maxEndTrim = originalDurationS - startTrimSeconds - MINIMUM_REMAINING_DURATION_SECONDS;
+    const newEndTrim = Math.max(0, Math.min(value, maxEndTrim));
+    setEndTrimSeconds(newEndTrim);
+  };
+
+  // Button handlers for start point adjustment
+  const handleStartBack = () => {
+    if (startTrimSeconds > 0) {
+      const newStartTrim = Math.max(0, startTrimSeconds - 1);
+      setStartTrimSeconds(newStartTrim);
+    }
+  };
+
+  const handleStartForward = () => {
+    const maxStartTrim = originalDurationS - endTrimSeconds - MINIMUM_REMAINING_DURATION_SECONDS;
+    if (startTrimSeconds < maxStartTrim) {
+      const newStartTrim = Math.min(maxStartTrim, startTrimSeconds + 1);
+      setStartTrimSeconds(newStartTrim);
+    }
+  };
+
+  // Button handlers for end point adjustment
+  const handleEndBack = () => {
+    const maxEndTrim = originalDurationS - startTrimSeconds - MINIMUM_REMAINING_DURATION_SECONDS;
+    if (endTrimSeconds < maxEndTrim) {
+      const newEndTrim = Math.min(maxEndTrim, endTrimSeconds + 1);
+      setEndTrimSeconds(newEndTrim);
+    }
+  };
+
+  const handleEndForward = () => {
+    if (endTrimSeconds > 0) {
+      const newEndTrim = Math.max(0, endTrimSeconds - 1);
+      setEndTrimSeconds(newEndTrim);
+    }
+  };
+
+  const handleConfirm = () => {
+    if (isValid && !isLoading) {
+      onConfirm(startTrimSeconds, endTrimSeconds);
+    }
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  if (!open) return null;
+
+  const maxStartTrim = originalDurationS - endTrimSeconds - MINIMUM_REMAINING_DURATION_SECONDS;
+  const maxEndTrim = originalDurationS - startTrimSeconds - MINIMUM_REMAINING_DURATION_SECONDS;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4"
+      onClick={handleBackdropClick}
+    >
+      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl max-w-2xl w-full p-6 border border-gray-200 dark:border-gray-800">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
+          Crop Workout
+        </h2>
+
+        <div className="mb-6 space-y-4">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Trim time from the beginning or end of your workout. The original data will be preserved for audit trail.
+          </p>
+
+          {/* Timeline Visualization */}
+          <div className="relative">
+            <div className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+              Timeline (drag handles to adjust)
+            </div>
+            <div className="relative h-12 bg-gray-200 dark:bg-gray-700 rounded-lg overflow-hidden">
+              {/* Trimmed start section */}
+              {startTrimSeconds > 0 && (
+                <div
+                  className="absolute left-0 top-0 h-full bg-red-300 dark:bg-red-900/50"
+                  style={{ width: `${(startTrimSeconds / originalDurationS) * 100}%` }}
+                />
+              )}
+              {/* Trimmed end section */}
+              {endTrimSeconds > 0 && (
+                <div
+                  className="absolute right-0 top-0 h-full bg-red-300 dark:bg-red-900/50"
+                  style={{ width: `${(endTrimSeconds / originalDurationS) * 100}%` }}
+                />
+              )}
+              {/* Remaining section */}
+              <div
+                className="absolute left-0 top-0 h-full bg-green-300 dark:bg-green-900/50"
+                style={{
+                  left: `${(startTrimSeconds / originalDurationS) * 100}%`,
+                  width: `${(newDurationS / originalDurationS) * 100}%`,
+                }}
+              />
+              {/* Start handle */}
+              <input
+                type="range"
+                min="0"
+                max={maxStartTrim}
+                value={startTrimSeconds}
+                onChange={(e) => handleStartSliderChange(parseInt(e.target.value, 10))}
+                className="absolute left-0 top-0 w-full h-full opacity-0 cursor-pointer z-10"
+                style={{ pointerEvents: 'auto' }}
+              />
+              {/* End handle */}
+              <input
+                type="range"
+                min="0"
+                max={maxEndTrim}
+                value={endTrimSeconds}
+                onChange={(e) => handleEndSliderChange(parseInt(e.target.value, 10))}
+                className="absolute right-0 top-0 w-full h-full opacity-0 cursor-pointer z-10"
+                style={{ pointerEvents: 'auto' }}
+              />
+            </div>
+            <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-1">
+              <span>Start</span>
+              <span>End</span>
+            </div>
+            {/* Navigation Buttons */}
+            <div className="flex justify-between items-center mt-3">
+              {/* Left side buttons for start point */}
+              <div className="flex gap-2">
+                <button
+                  onClick={handleStartBack}
+                  disabled={startTrimSeconds === 0}
+                  className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-gray-100 dark:disabled:hover:bg-gray-800"
+                  title="Move start point later (trim less from start)"
+                >
+                  ← Back
+                </button>
+                <button
+                  onClick={handleStartForward}
+                  disabled={startTrimSeconds >= maxStartTrim}
+                  className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-gray-100 dark:disabled:hover:bg-gray-800"
+                  title="Move start point earlier (trim more from start)"
+                >
+                  Forward →
+                </button>
+              </div>
+              {/* Right side buttons for end point */}
+              <div className="flex gap-2">
+                <button
+                  onClick={handleEndBack}
+                  disabled={endTrimSeconds >= maxEndTrim}
+                  className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-gray-100 dark:disabled:hover:bg-gray-800"
+                  title="Move end point earlier (trim more from end)"
+                >
+                  ← Back
+                </button>
+                <button
+                  onClick={handleEndForward}
+                  disabled={endTrimSeconds === 0}
+                  className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-gray-100 dark:disabled:hover:bg-gray-800"
+                  title="Move end point later (trim less from end)"
+                >
+                  Forward →
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Trim Inputs */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Trim from Start
+              </label>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={startTrimInput}
+                  onChange={(e) => handleStartTrimInputChange(e.target.value)}
+                  placeholder="M:SS"
+                  className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <div className="px-3 py-2 text-sm text-gray-600 dark:text-gray-400">
+                  {formatDuration(startTrimSeconds)}
+                </div>
+              </div>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Trim from End
+              </label>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={endTrimInput}
+                  onChange={(e) => handleEndTrimInputChange(e.target.value)}
+                  placeholder="M:SS"
+                  className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <div className="px-3 py-2 text-sm text-gray-600 dark:text-gray-400">
+                  {formatDuration(endTrimSeconds)}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Preview */}
+          <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+            <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Preview</div>
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <div className="text-gray-500 dark:text-gray-400">Original</div>
+                <div className="font-semibold text-gray-900 dark:text-gray-100">
+                  {formatDuration(originalDurationS)} • {formatDistance(originalDistanceM, unitPreference)}
+                </div>
+              </div>
+              <div>
+                <div className="text-gray-500 dark:text-gray-400">After Crop</div>
+                <div className="font-semibold text-gray-900 dark:text-gray-100">
+                  {formatDuration(newDurationS)} • {formatDistance(newDistanceM, unitPreference)}
+                </div>
+              </div>
+            </div>
+            {!isValid && newDurationS < MINIMUM_REMAINING_DURATION_SECONDS && (
+              <div className="mt-2 text-xs text-red-600 dark:text-red-400">
+                Minimum remaining duration is {formatDuration(MINIMUM_REMAINING_DURATION_SECONDS)}
+              </div>
+            )}
+          </div>
+
+          <p className="text-xs text-red-600 dark:text-red-400 font-medium">
+            This action cannot be undone. Original data will be preserved for audit trail.
+          </p>
+        </div>
+
+        <div className="flex gap-3 justify-end">
+          <button
+            onClick={onClose}
+            disabled={isLoading}
+            className="px-4 py-2 rounded-lg font-medium transition-colors bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={!isValid || isLoading}
+            className="px-4 py-2 rounded-lg font-medium transition-colors bg-blue-600 text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isLoading ? 'Cropping...' : 'Crop Workout'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/hooks/useWorkoutMutations.ts
+++ b/frontend/hooks/useWorkoutMutations.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { updateWorkout, deleteWorkout } from '@/lib/api';
+import { updateWorkout, deleteWorkout, cropWorkout } from '@/lib/api';
 import { invalidateWorkoutQueries } from '@/lib/queryUtils';
 
 export function useWorkoutMutations(workoutId: string) {
@@ -23,6 +23,14 @@ export function useWorkoutMutations(workoutId: string) {
     },
   });
 
+  const cropWorkoutMutation = useMutation({
+    mutationFn: ({ startTrimSeconds, endTrimSeconds }: { startTrimSeconds: number; endTrimSeconds: number }) =>
+      cropWorkout(workoutId, startTrimSeconds, endTrimSeconds),
+    onSuccess: () => {
+      invalidateWorkoutQueries(queryClient, workoutId);
+    },
+  });
+
   const handleDeleteWorkout = () => {
     if (window.confirm('Are you sure you want to delete this workout? This action cannot be undone.')) {
       deleteWorkoutMutation.mutate();
@@ -32,6 +40,7 @@ export function useWorkoutMutations(workoutId: string) {
   return {
     updateWorkoutMutation,
     deleteWorkoutMutation,
+    cropWorkoutMutation,
     handleDeleteWorkout,
   };
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -785,6 +785,34 @@ export async function recalculateWorkoutSplits(workoutId: string): Promise<{ id:
   return response.json();
 }
 
+export interface CropWorkoutRequest {
+  startTrimSeconds: number;
+  endTrimSeconds: number;
+}
+
+export async function cropWorkout(
+  workoutId: string,
+  startTrimSeconds: number,
+  endTrimSeconds: number
+): Promise<WorkoutDetail> {
+  const response = await fetch(`${API_BASE_URL}/workouts/${workoutId}/crop`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ startTrimSeconds, endTrimSeconds }),
+  });
+
+  if (response.status === 404) {
+    throw new Error('Workout not found');
+  }
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: `HTTP error! status: ${response.status}` }));
+    throw new Error(error.error || `Failed to crop workout: ${response.status}`);
+  }
+
+  return response.json();
+}
+
 export interface VersionResponse {
   version: string;
   buildDate: string;


### PR DESCRIPTION
Add ability to crop workouts by trimming time from the beginning and/or end, allowing users to match recorded workout times with official race times.

Backend Changes:
- Add WorkoutCropService to handle workout cropping logic
  - Filters and reindexes time series data based on trim parameters
  - Trims route coordinates using time-to-coordinate mapping
  - Recalculates all workout aggregates (distance, pace, elevation, HR stats)
  - Updates workout duration and start timestamp
  - Preserves original raw data for audit trail
- Add POST /workouts/{id}/crop endpoint with validation
- Register WorkoutCropService in dependency injection

Frontend Changes:
- Add CropWorkoutDialog component with interactive timeline UI
  - Visual timeline slider for selecting start/end trim points
  - Manual time input (MM:SS format) with validation
  - Real-time preview of new duration and distance
  - Minimum duration validation (10 seconds)
- Integrate crop functionality into WorkoutDetailHeader
- Add crop mutation hook to useWorkoutMutations
- Add cropWorkout API function

Documentation:
- Add WorkoutCropFeature.md with feature specification and implementation details

The feature maintains data integrity by recalculating all derived metrics (splits, relative effort, aggregates) from the cropped data while preserving original raw files for audit purposes.