### PR TITLE
feat: Extract sensor data from FIT RecordMesg (#63)

### DIFF
--- a/api/Services/FitParserService.cs
+++ b/api/Services/FitParserService.cs
@@ -121,7 +121,12 @@ public class FitParserService
                         Latitude = latitude.Value,
                         Longitude = longitude.Value,
                         Time = timestamp.Value,
-                        Elevation = altitude
+                        Elevation = altitude,
+                        // Extract sensor data from RecordMesg
+                        HeartRateBpm = record.GetHeartRate(),
+                        CadenceRpm = record.GetCadence(),
+                        PowerWatts = record.GetPower(),
+                        TemperatureC = record.GetTemperature()
                     };
 
                     trackPoints.Add(point);


### PR DESCRIPTION
Extract heart rate, cadence, power, and temperature sensor data from FIT RecordMesg messages and populate GpxPoint properties during FIT file parsing.

Changes:
- Added HeartRateBpm extraction from RecordMesg.GetHeartRate()
- Added CadenceRpm extraction from RecordMesg.GetCadence()
- Added PowerWatts extraction from RecordMesg.GetPower()
- Added TemperatureC extraction from RecordMesg.GetTemperature()

All sensor data fields are nullable and handle missing data gracefully, maintaining backward compatibility with FIT files that don't contain sensor data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Populate `GpxPoint` with heart rate, cadence, power, and temperature from FIT `RecordMesg` during parsing.
> 
> - **FIT parsing**:
>   - Populate `GpxPoint` with sensor data extracted from `RecordMesg`: `HeartRateBpm`, `CadenceRpm`, `PowerWatts`, `TemperatureC` in `api/Services/FitParserService.cs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bb09ac26f3ee2d24ae4b966bfda9133b16ab8f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->