### PR TITLE
feat: Create time series records from FIT files

### DIFF
--- a/api/Endpoints/WorkoutsEndpoints.cs
+++ b/api/Endpoints/WorkoutsEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
@@ -7,6 +8,7 @@ using Tempo.Api.Models;
 using Tempo.Api.Services;
 using static Tempo.Api.Services.WorkoutQueryService;
 using static Tempo.Api.Services.DeviceExtractionService;
+using Dynastream.Fit;
 
 namespace Tempo.Api.Endpoints;
 
@@ -2706,6 +2708,59 @@ public static class WorkoutsEndpoints
     }
 
     /// <summary>
+    /// Creates time-series records from FIT RecordMesg messages with sensor data.
+    /// </summary>
+    private static List<WorkoutTimeSeries> CreateTimeSeriesFromFitRecords(
+        Guid workoutId,
+        DateTime startTime,
+        ReadOnlyCollection<RecordMesg> records)
+    {
+        var timeSeries = new List<WorkoutTimeSeries>();
+
+        foreach (var record in records)
+        {
+            var timestamp = record.GetTimestamp()?.GetDateTime().ToUniversalTime();
+            if (timestamp == null) continue;
+
+            var elapsedSeconds = (int)(timestamp.Value - startTime).TotalSeconds;
+            if (elapsedSeconds < 0) continue; // Skip records before start time
+
+            // Only create record if there's sensor data or elevation
+            var hasSensorData = record.GetHeartRate().HasValue ||
+                               record.GetCadence().HasValue ||
+                               record.GetPower().HasValue ||
+                               record.GetSpeed().HasValue ||
+                               record.GetEnhancedSpeed().HasValue ||
+                               record.GetTemperature().HasValue ||
+                               record.GetAltitude().HasValue ||
+                               record.GetEnhancedAltitude().HasValue;
+
+            if (hasSensorData)
+            {
+                var timeSeriesRecord = new WorkoutTimeSeries
+                {
+                    Id = Guid.NewGuid(),
+                    WorkoutId = workoutId,
+                    ElapsedSeconds = elapsedSeconds,
+                    HeartRateBpm = record.GetHeartRate(),
+                    CadenceRpm = record.GetCadence(),
+                    PowerWatts = record.GetPower(),
+                    SpeedMps = record.GetEnhancedSpeed().HasValue ? (double?)record.GetEnhancedSpeed().Value : (record.GetSpeed().HasValue ? (double?)record.GetSpeed().Value : null),
+                    TemperatureC = record.GetTemperature(),
+                    ElevationM = record.GetEnhancedAltitude().HasValue ? (double?)record.GetEnhancedAltitude().Value : (record.GetAltitude().HasValue ? (double?)record.GetAltitude().Value : null),
+                    GradePercent = record.GetGrade().HasValue ? (double?)record.GetGrade().Value : null,
+                    VerticalSpeedMps = record.GetVerticalSpeed().HasValue ? (double?)record.GetVerticalSpeed().Value : null,
+                    DistanceM = record.GetDistance().HasValue ? (double?)record.GetDistance().Value : null
+                };
+
+                timeSeries.Add(timeSeriesRecord);
+            }
+        }
+
+        return timeSeries;
+    }
+
+    /// <summary>
     /// Calculates aggregate metrics (max/avg/min) from time-series data and updates workout.
     /// </summary>
     private static void CalculateAggregateMetricsFromTimeSeries(Workout workout, List<WorkoutTimeSeries> timeSeries)
@@ -2920,6 +2975,15 @@ public static class WorkoutsEndpoints
             if (parseResult != null)
             {
                 timeSeries = CreateTimeSeriesFromGpxTrackPoints(workout.Id, startedAtUtc, trackPoints);
+                if (timeSeries.Count > 0)
+                {
+                    CalculateAggregateMetricsFromTimeSeries(workout, timeSeries);
+                }
+            }
+            // Create time-series from FIT records if available
+            else if (fitResult != null && fitResult.RecordMesgs.Count > 0)
+            {
+                timeSeries = CreateTimeSeriesFromFitRecords(workout.Id, startedAtUtc, fitResult.RecordMesgs);
                 if (timeSeries.Count > 0)
                 {
                     CalculateAggregateMetricsFromTimeSeries(workout, timeSeries);

--- a/api/Services/FitParserService.cs
+++ b/api/Services/FitParserService.cs
@@ -27,6 +27,7 @@ public class FitParserService
         public double? ElevationGainMeters { get; set; }
         public List<GpxParserService.GpxPoint> TrackPoints { get; set; } = new();
         public string? RawFitDataJson { get; set; }  // JSON string for RawFitData field
+        public ReadOnlyCollection<RecordMesg> RecordMesgs { get; set; } = new ReadOnlyCollection<RecordMesg>(new List<RecordMesg>());
     }
 
     public FitParseResult ParseFit(Stream fitStream)
@@ -186,7 +187,8 @@ public class FitParserService
                 DistanceMeters = totalDistance,
                 ElevationGainMeters = elevationGain,
                 TrackPoints = trackPoints,
-                RawFitDataJson = rawFitData
+                RawFitDataJson = rawFitData,
+                RecordMesgs = records
             };
         }
         catch (FitException ex)


### PR DESCRIPTION
Implement time series data creation from FIT file RecordMesg messages,
enabling time series charts and analytics for FIT imports. #64 

Changes:
- Add RecordMesgs property to FitParseResult to pass RecordMesg collection
  through parsing pipeline
- Create CreateTimeSeriesFromFitRecords method in WorkoutsEndpoints and
  BulkImportService to extract sensor data from FIT RecordMesg messages
- Extract all available sensor data: heart rate, cadence, power, speed
  (prefers enhanced), temperature, elevation (prefers enhanced), grade,
  vertical speed, and distance
- Integrate FIT time series creation into both single-file and bulk
  import workflows
- Calculate aggregate metrics (max/avg/min) from FIT time series data

The implementation follows the same pattern as GPX time series creation,
ensuring consistency across file formats. Time series records are only
created when sensor data is present, maintaining backward compatibility
with FIT files that don't contain sensor data.

Files modified:
- api/Services/FitParserService.cs
- api/Endpoints/WorkoutsEndpoints.cs
- api/Services/BulkImportService.cs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extracts sensor time-series from FIT RecordMesg and computes aggregates, integrating into single and bulk import flows.
> 
> - **FIT parsing**
>   - Add `RecordMesgs` to `FitParseResult` and propagate parsed `RecordMesg` collection.
> - **Time-series generation**
>   - Implement `CreateTimeSeriesFromFitRecords` in `api/Endpoints/WorkoutsEndpoints.cs` and `api/Services/BulkImportService.cs` to build `WorkoutTimeSeries` from FIT data (HR, cadence, power, speed, temperature, elevation, grade, vertical speed, distance).
>   - Prefer enhanced speed/altitude when available; skip records without sensor data; align timestamps to workout start.
> - **Import workflows**
>   - Integrate FIT time-series creation and `CalculateAggregateMetricsFromTimeSeries` into both single-file and bulk imports (used when GPX tracks are absent).
> - **Minor additions**
>   - Add `Dynastream.Fit` usages where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7d905ec4386ed817c3e6b4a0359af0a0eddc611. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->