### PR TITLE
fix: Resolve DateTime ambiguity in FIT time series implementation

### DIFF
--- a/api/Endpoints/WorkoutsEndpoints.cs
+++ b/api/Endpoints/WorkoutsEndpoints.cs
@@ -8,7 +8,6 @@ using Tempo.Api.Models;
 using Tempo.Api.Services;
 using static Tempo.Api.Services.WorkoutQueryService;
 using static Tempo.Api.Services.DeviceExtractionService;
-using Dynastream.Fit;
 
 namespace Tempo.Api.Endpoints;
 
@@ -2713,7 +2712,7 @@ public static class WorkoutsEndpoints
     private static List<WorkoutTimeSeries> CreateTimeSeriesFromFitRecords(
         Guid workoutId,
         DateTime startTime,
-        ReadOnlyCollection<RecordMesg> records)
+        ReadOnlyCollection<Dynastream.Fit.RecordMesg> records)
     {
         var timeSeries = new List<WorkoutTimeSeries>();
 

--- a/api/Services/BulkImportService.cs
+++ b/api/Services/BulkImportService.cs
@@ -4,7 +4,6 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Tempo.Api.Data;
 using Tempo.Api.Models;
-using Dynastream.Fit;
 
 namespace Tempo.Api.Services;
 
@@ -681,7 +680,7 @@ public class BulkImportService
     private List<WorkoutTimeSeries> CreateTimeSeriesFromFitRecords(
         Guid workoutId,
         DateTime startTime,
-        ReadOnlyCollection<RecordMesg> records)
+        ReadOnlyCollection<Dynastream.Fit.RecordMesg> records)
     {
         var timeSeries = new List<WorkoutTimeSeries>();
 

--- a/api/Services/FitParserService.cs
+++ b/api/Services/FitParserService.cs
@@ -27,7 +27,7 @@ public class FitParserService
         public double? ElevationGainMeters { get; set; }
         public List<GpxParserService.GpxPoint> TrackPoints { get; set; } = new();
         public string? RawFitDataJson { get; set; }  // JSON string for RawFitData field
-        public ReadOnlyCollection<RecordMesg> RecordMesgs { get; set; } = new ReadOnlyCollection<RecordMesg>(new List<RecordMesg>());
+        public ReadOnlyCollection<Dynastream.Fit.RecordMesg> RecordMesgs { get; set; } = new ReadOnlyCollection<Dynastream.Fit.RecordMesg>(new List<Dynastream.Fit.RecordMesg>());
     }
 
     public FitParseResult ParseFit(Stream fitStream)


### PR DESCRIPTION
Fix build errors caused by ambiguous reference between System.DateTime and Dynastream.Fit.DateTime after adding using Dynastream.Fit statements.

Changes:
- Remove using Dynastream.Fit from WorkoutsEndpoints.cs and BulkImportService.cs to avoid DateTime namespace conflicts
- Fully qualify RecordMesg as Dynastream.Fit.RecordMesg in method signatures and FitParseResult class
- Maintain existing using Dynastream.Fit in FitParserService.cs where it's already present and doesn't cause conflicts

This resolves CS0104 compilation errors that were preventing the build from succeeding. The DateTime ambiguity occurred because both System.DateTime and Dynastream.Fit.DateTime were in scope after adding the using statement.

Files modified:
- api/Endpoints/WorkoutsEndpoints.cs
- api/Services/BulkImportService.cs
- api/Services/FitParserService.cs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolve System.DateTime vs Dynastream.Fit.DateTime ambiguity by removing broad FIT using directives and fully qualifying RecordMesg references.
> 
> - **FIT type qualification**:
>   - Update `CreateTimeSeriesFromFitRecords` signatures in `api/Endpoints/WorkoutsEndpoints.cs` and `api/Services/BulkImportService.cs` to use `ReadOnlyCollection` of `Dynastream.Fit.RecordMesg`.
>   - Remove `using Dynastream.Fit` from those files to avoid `DateTime` conflicts.
>   - In `api/Services/FitParserService.cs`, set `FitParseResult.RecordMesgs` to `ReadOnlyCollection<Dynastream.Fit.RecordMesg>` (retaining existing `using`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b1f3dc2b6c2468b97ee6d1f454e5068accd1f8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->