### PR TITLE
feat: Extract and validate additional FIT data (speed, grade, vertica…

### DIFF
--- a/api/Endpoints/WorkoutsEndpoints.cs
+++ b/api/Endpoints/WorkoutsEndpoints.cs
@@ -2725,16 +2725,16 @@ public static class WorkoutsEndpoints
             if (elapsedSeconds < 0) continue; // Skip records before start time
 
             // Extract and validate all fields first
-            // Extract and validate speed (must be non-negative and not NaN)
+            // Extract and validate speed (must be non-negative, finite, and not NaN)
             // Prefer enhanced speed if valid, otherwise fall back to standard speed
             var enhancedSpeed = record.GetEnhancedSpeed();
             var standardSpeed = record.GetSpeed();
             double? validatedSpeed = null;
-            if (enhancedSpeed.HasValue && !double.IsNaN(enhancedSpeed.Value) && enhancedSpeed.Value >= 0)
+            if (enhancedSpeed.HasValue && !double.IsNaN(enhancedSpeed.Value) && !double.IsInfinity(enhancedSpeed.Value) && enhancedSpeed.Value >= 0)
             {
                 validatedSpeed = (double?)enhancedSpeed.Value;
             }
-            else if (standardSpeed.HasValue && !double.IsNaN(standardSpeed.Value) && standardSpeed.Value >= 0)
+            else if (standardSpeed.HasValue && !double.IsNaN(standardSpeed.Value) && !double.IsInfinity(standardSpeed.Value) && standardSpeed.Value >= 0)
             {
                 validatedSpeed = (double?)standardSpeed.Value;
             }
@@ -2751,13 +2751,13 @@ public static class WorkoutsEndpoints
                 }
             }
 
-            // Extract and validate vertical speed (reasonable range -50 to 50 m/s, exclude NaN)
+            // Extract and validate vertical speed (reasonable range -50 to 50 m/s, exclude NaN and Infinity)
             var verticalSpeed = record.GetVerticalSpeed();
             double? validatedVerticalSpeed = null;
             if (verticalSpeed.HasValue)
             {
                 var vsValue = verticalSpeed.Value;
-                if (!double.IsNaN(vsValue) && vsValue >= -50.0 && vsValue <= 50.0)
+                if (!double.IsNaN(vsValue) && !double.IsInfinity(vsValue) && vsValue >= -50.0 && vsValue <= 50.0)
                 {
                     validatedVerticalSpeed = (double)vsValue;
                 }
@@ -2770,15 +2770,15 @@ public static class WorkoutsEndpoints
             var power = record.GetPower();
             var temperature = record.GetTemperature();
             
-            // Extract elevation (prefer enhanced, exclude NaN)
+            // Extract elevation (prefer enhanced, exclude NaN and Infinity)
             double? elevation = null;
             var enhancedAltitude = record.GetEnhancedAltitude();
             var standardAltitude = record.GetAltitude();
-            if (enhancedAltitude.HasValue && !double.IsNaN(enhancedAltitude.Value))
+            if (enhancedAltitude.HasValue && !double.IsNaN(enhancedAltitude.Value) && !double.IsInfinity(enhancedAltitude.Value))
             {
                 elevation = (double?)enhancedAltitude.Value;
             }
-            else if (standardAltitude.HasValue && !double.IsNaN(standardAltitude.Value))
+            else if (standardAltitude.HasValue && !double.IsNaN(standardAltitude.Value) && !double.IsInfinity(standardAltitude.Value))
             {
                 elevation = (double?)standardAltitude.Value;
             }

--- a/api/Services/BulkImportService.cs
+++ b/api/Services/BulkImportService.cs
@@ -693,16 +693,16 @@ public class BulkImportService
             if (elapsedSeconds < 0) continue; // Skip records before start time
 
             // Extract and validate all fields first
-            // Extract and validate speed (must be non-negative and not NaN)
+            // Extract and validate speed (must be non-negative, finite, and not NaN)
             // Prefer enhanced speed if valid, otherwise fall back to standard speed
             var enhancedSpeed = record.GetEnhancedSpeed();
             var standardSpeed = record.GetSpeed();
             double? validatedSpeed = null;
-            if (enhancedSpeed.HasValue && !double.IsNaN(enhancedSpeed.Value) && enhancedSpeed.Value >= 0)
+            if (enhancedSpeed.HasValue && !double.IsNaN(enhancedSpeed.Value) && !double.IsInfinity(enhancedSpeed.Value) && enhancedSpeed.Value >= 0)
             {
                 validatedSpeed = (double?)enhancedSpeed.Value;
             }
-            else if (standardSpeed.HasValue && !double.IsNaN(standardSpeed.Value) && standardSpeed.Value >= 0)
+            else if (standardSpeed.HasValue && !double.IsNaN(standardSpeed.Value) && !double.IsInfinity(standardSpeed.Value) && standardSpeed.Value >= 0)
             {
                 validatedSpeed = (double?)standardSpeed.Value;
             }
@@ -719,13 +719,13 @@ public class BulkImportService
                 }
             }
 
-            // Extract and validate vertical speed (reasonable range -50 to 50 m/s, exclude NaN)
+            // Extract and validate vertical speed (reasonable range -50 to 50 m/s, exclude NaN and Infinity)
             var verticalSpeed = record.GetVerticalSpeed();
             double? validatedVerticalSpeed = null;
             if (verticalSpeed.HasValue)
             {
                 var vsValue = verticalSpeed.Value;
-                if (!double.IsNaN(vsValue) && vsValue >= -50.0 && vsValue <= 50.0)
+                if (!double.IsNaN(vsValue) && !double.IsInfinity(vsValue) && vsValue >= -50.0 && vsValue <= 50.0)
                 {
                     validatedVerticalSpeed = (double)vsValue;
                 }
@@ -738,15 +738,15 @@ public class BulkImportService
             var power = record.GetPower();
             var temperature = record.GetTemperature();
             
-            // Extract elevation (prefer enhanced, exclude NaN)
+            // Extract elevation (prefer enhanced, exclude NaN and Infinity)
             double? elevation = null;
             var enhancedAltitude = record.GetEnhancedAltitude();
             var standardAltitude = record.GetAltitude();
-            if (enhancedAltitude.HasValue && !double.IsNaN(enhancedAltitude.Value))
+            if (enhancedAltitude.HasValue && !double.IsNaN(enhancedAltitude.Value) && !double.IsInfinity(enhancedAltitude.Value))
             {
                 elevation = (double?)enhancedAltitude.Value;
             }
-            else if (standardAltitude.HasValue && !double.IsNaN(standardAltitude.Value))
+            else if (standardAltitude.HasValue && !double.IsNaN(standardAltitude.Value) && !double.IsInfinity(standardAltitude.Value))
             {
                 elevation = (double?)standardAltitude.Value;
             }


### PR DESCRIPTION
…l speed)

Implements #65 to enhance FIT file parsing by extracting speed, grade, vertical speed, and distance from RecordMesg messages with proper data validation.

Changes:
- Updated hasSensorData check to include grade, vertical speed, and distance fields, ensuring records with only these fields are included in time series
- Added speed validation: rejects negative values (sets to null)
- Added grade validation: clamps values to -100 to 100 percentage range
- Added vertical speed validation: accepts values in -50 to 50 m/s range, rejects extreme values as invalid data
- Fixed DateTime ambiguity in method signatures by using System.DateTime explicitly

Files modified:
- api/Endpoints/WorkoutsEndpoints.cs
- api/Services/BulkImportService.cs

The implementation ensures that:
- Records with only grade/vertical speed/distance are not skipped
- Invalid data (negative speeds, extreme vertical speeds) is filtered out
- Grade values are normalized to valid percentage range
- All extracted data is properly validated before being stored in time series

This completes the extraction of additional FIT data fields as specified in #65, enabling analysis of pace variations, elevation changes, and climbing/descending patterns in FIT file imports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances FIT `RecordMesg` parsing to validate and capture speed, grade, vertical speed, elevation, and distance, creating time-series entries only when any validated data exists.
> 
> - **Backend**
>   - **FIT time-series parsing (`CreateTimeSeriesFromFitRecords`)**
>     - Validate speed (prefer `enhancedSpeed`; non-negative, finite) and assign to `SpeedMps`.
>     - Clamp `GradePercent` to [-100, 100]; ignore NaN/Infinity.
>     - Validate `VerticalSpeedMps` within [-50, 50] m/s; ignore invalids.
>     - Validate elevation (prefer enhanced) and `DistanceM` (non-negative, finite).
>     - Only create `WorkoutTimeSeries` when at least one validated field (HR, cadence, power, speed, temp, elevation, grade, vertical speed, distance) is present.
>     - Implemented in `api/Endpoints/WorkoutsEndpoints.cs` and `api/Services/BulkImportService.cs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8110098bfdad2982973f331823eb4228da54fd5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->