### PR TITLE
feat: Add speed aggregate calculation from FIT time series (#66)

### DIFF
--- a/api/Endpoints/WorkoutsEndpoints.cs
+++ b/api/Endpoints/WorkoutsEndpoints.cs
@@ -2874,7 +2874,11 @@ public static class WorkoutsEndpoints
             .Select(ts => ts.SpeedMps!.Value).ToList();
         if (speeds.Any())
         {
-            workout.MaxSpeedMps = speeds.Max();
+            // Only set if not already populated (e.g., from Strava CSV or GPX calculated data)
+            if (!workout.MaxSpeedMps.HasValue)
+            {
+                workout.MaxSpeedMps = speeds.Max();
+            }
         }
         
         // Calculate average speed using total distance / duration (matches GPX import behavior)

--- a/api/Services/BulkImportService.cs
+++ b/api/Services/BulkImportService.cs
@@ -842,7 +842,11 @@ public class BulkImportService
             .Select(ts => ts.SpeedMps!.Value).ToList();
         if (speeds.Any())
         {
-            workout.MaxSpeedMps = speeds.Max();
+            // Only set if not already populated (e.g., from Strava CSV or GPX calculated data)
+            if (!workout.MaxSpeedMps.HasValue)
+            {
+                workout.MaxSpeedMps = speeds.Max();
+            }
         }
         
         // Calculate average speed using total distance / duration (matches GPX import behavior)


### PR DESCRIPTION
Add max and average speed calculation to CalculateAggregateMetricsFromTimeSeries() method for both single and bulk import workflows. Speed aggregates are now calculated from time series data when FIT files contain speed information, completing the aggregate metrics calculation for FIT imports.

Changes:
- Add speed aggregate calculation in WorkoutsEndpoints.cs
- Add speed aggregate calculation in BulkImportService.cs
- Calculate MaxSpeedMps and AvgSpeedMps from SpeedMps values in time series

This completes #66 which ensures aggregate metrics are calculated from time series data for FIT imports, matching the behavior for GPX imports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Compute max and average speed from time-series data (when available) during single and bulk imports, without overwriting existing values.
> 
> - **Metrics**:
>   - `api/Endpoints/WorkoutsEndpoints.cs` → `CalculateAggregateMetricsFromTimeSeries(...)`:
>     - Derive `MaxSpeedMps` from time-series `SpeedMps` (only if not already set).
>     - Derive `AvgSpeedMps` as `DistanceM / DurationS` when unset.
>   - `api/Services/BulkImportService.cs` → `CalculateAggregateMetricsFromTimeSeries(...)`:
>     - Same speed aggregate logic as above for bulk imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 252aa2b530593b41fcf9b69562b87ea2fc40fb0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->