### PR TITLE
feat: Add backward compatibility for FIT files without sensor data (#67)

### DIFF
--- a/api/Services/BulkImportService.cs
+++ b/api/Services/BulkImportService.cs
@@ -307,13 +307,24 @@ public class BulkImportService
                 }
             }
             // Create time-series from FIT records if available
-            else if (fitResult != null && fitResult.RecordMesgs.Count > 0)
+            // Defensive null check for backward compatibility with FIT files without sensor data
+            else if (fitResult != null && fitResult.RecordMesgs != null && fitResult.RecordMesgs.Count > 0)
             {
                 timeSeries = CreateTimeSeriesFromFitRecords(workout.Id, startedAtUtc, fitResult.RecordMesgs);
                 if (timeSeries.Count > 0)
                 {
                     CalculateAggregateMetricsFromTimeSeries(workout, timeSeries);
                 }
+                else
+                {
+                    // Log when FIT file has no sensor data but workout is still created successfully
+                    _logger.LogInformation("FIT file imported with no sensor data. Workout created with available data (GPS, elevation, distance).");
+                }
+            }
+            else if (fitResult != null)
+            {
+                // Log when FIT file has no RecordMesgs or they're empty
+                _logger.LogInformation("FIT file imported with no RecordMesg data. Workout created with available data (GPS, elevation, distance).");
             }
 
             // Fetch weather data
@@ -676,13 +687,25 @@ public class BulkImportService
 
     /// <summary>
     /// Creates time-series records from FIT RecordMesg messages with sensor data.
+    /// Returns an empty list if no sensor data is available, ensuring backward compatibility
+    /// with FIT files that don't contain sensor data.
     /// </summary>
+    /// <param name="workoutId">The workout ID to associate time series records with.</param>
+    /// <param name="startTime">The workout start time for calculating elapsed seconds.</param>
+    /// <param name="records">The FIT RecordMesg collection. Can be null or empty for backward compatibility.</param>
+    /// <returns>List of WorkoutTimeSeries records. Empty list if no sensor data is available.</returns>
     private List<WorkoutTimeSeries> CreateTimeSeriesFromFitRecords(
         Guid workoutId,
         DateTime startTime,
         ReadOnlyCollection<Dynastream.Fit.RecordMesg> records)
     {
         var timeSeries = new List<WorkoutTimeSeries>();
+
+        // Defensive null check for backward compatibility
+        if (records == null || records.Count == 0)
+        {
+            return timeSeries;
+        }
 
         foreach (var record in records)
         {

--- a/api/Services/FitParserService.cs
+++ b/api/Services/FitParserService.cs
@@ -124,6 +124,8 @@ public class FitParserService
                         Time = timestamp.Value,
                         Elevation = altitude,
                         // Extract sensor data from RecordMesg
+                        // All Get methods return nullable types and never throw exceptions,
+                        // ensuring backward compatibility with FIT files without sensor data
                         HeartRateBpm = record.GetHeartRate(),
                         CadenceRpm = record.GetCadence(),
                         PowerWatts = record.GetPower(),


### PR DESCRIPTION
Ensure FIT files without sensor data import successfully by adding defensive null checks, logging, and explicit documentation throughout the import pipeline.

Changes:
- Add explicit null checks for RecordMesgs before accessing Count property in both WorkoutsEndpoints.cs and BulkImportService.cs
- Add defensive null check inside CreateTimeSeriesFromFitRecords methods to handle null or empty RecordMesg collections gracefully
- Add informational logging when FIT files have no sensor data or no RecordMesgs, indicating successful import with available data
- Enhance XML documentation for CreateTimeSeriesFromFitRecords methods explaining backward compatibility behavior
- Add comment in FitParserService.cs clarifying that sensor data extraction methods never throw exceptions (all return nullable types)

Backward Compatibility:
- FIT files without sensor data now import successfully
- Workouts are created with available data (GPS, elevation, distance)
- No time series records are created when no sensor data is available
- No errors or exceptions are thrown for missing sensor fields
- Existing FIT imports continue to work without breaking changes

This ensures users can import any FIT file regardless of data completeness, supporting older FIT files and files from devices without sensor capabilities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow FIT imports with missing sensor data by adding null-safe handling of RecordMesgs, early returns, and informational logging across endpoints and bulk import.
> 
> - **Import pipeline**:
>   - `api/Endpoints/WorkoutsEndpoints.cs` and `api/Services/BulkImportService.cs`:
>     - Add null checks for `fitResult.RecordMesgs` before use; handle empty collections.
>     - Log informational messages when FIT files lack sensor data or `RecordMesg` data.
>     - Continue creating workouts and metrics from available data; only create time series if records exist.
> - **Time series generation**:
>   - `CreateTimeSeriesFromFitRecords(...)` (both locations): document behavior and return empty list when `records` is null/empty; existing field validation retained.
> - **Parser notes**:
>   - `api/Services/FitParserService.cs`: add comment clarifying FIT getter methods return nullable types and won’t throw, ensuring compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d1cf9fc1dc122c80769b6eed30cee2e363fff25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->