### PR TITLE
fix: ensure VERSION file exists in frontend Docker build stage

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,6 +17,12 @@ RUN npm ci --legacy-peer-deps
 # Copy source code
 COPY . .
 
+# Ensure VERSION file exists (create from APP_VERSION if not present)
+# This ensures the file is always available for the runner stage
+RUN if [ ! -f VERSION ]; then \
+      echo "${APP_VERSION}" > VERSION; \
+    fi
+
 # Set environment variables
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_VERSION=$APP_VERSION


### PR DESCRIPTION
The frontend Dockerfile was attempting to copy /app/VERSION from the build stage to the runner stage, but the file wasn't being created during the build process. This caused Docker builds to fail with "not found" errors.

This change adds a step to create the VERSION file from the APP_VERSION build argument if it doesn't already exist, matching the pattern used in the API Dockerfile. This ensures the file is always available when copying to the runner stage.

Fixes Docker build error: "/app/VERSION: not found"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `VERSION` file is created during frontend Docker build to prevent copy errors in the runner stage.
> 
> - **Docker (frontend)**:
>   - Create `VERSION` from `APP_VERSION` in `frontend/Dockerfile` build stage if missing, ensuring it can be copied to the runner stage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e2923fb5d72df12214993aab7bd8c64af930ba3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->