### PR TITLE
test: Add comprehensive integration tests for Stats endpoints

### DIFF
--- a/api/Tempo.Api.Tests/IntegrationTests/StatsEndpointsTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/StatsEndpointsTests.cs
@@ -700,8 +700,11 @@ public class StatsEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         const int estOffsetMinutes = -300;
 
         // Calculate dates relative to current year to make test work regardless of when it runs
-        var now = DateTime.UtcNow;
-        var currentYear = now.Year;
+        // IMPORTANT: Match the endpoint's calculation - apply timezone offset first, then get year
+        // This prevents mismatch when test runs between midnight and 5 AM UTC on Jan 1st
+        var nowUtc = DateTime.UtcNow;
+        var nowInTimezone = nowUtc.AddMinutes(estOffsetMinutes);
+        var currentYear = nowInTimezone.Year;
         var previousYear = currentYear - 1;
         
         // Create a workout on Dec 31 of previous year at 11 PM EST


### PR DESCRIPTION
Add comprehensive integration test coverage for all 8 Stats endpoints, validating weekly stats, yearly stats, relative effort stats, best efforts, available periods/years, and edge cases with multiple years of data, different run types, and sparse/empty datasets.

## Test Coverage

### Weekly Stats (`/stats/weekly`) - 5 tests
- Daily miles calculation for current week
- Empty week handling (returns zeros)
- Timezone offset parameter support
- Correct day-of-week grouping (Monday-Sunday)
- Meter-to-mile conversion accuracy

### Relative Effort Stats (`/stats/relative-effort`) - 5 tests
- Cumulative relative effort calculation
- 3-week average from previous weeks
- Workouts without relative effort (skipped correctly)
- Empty week handling
- Timezone offset support

### Yearly Stats (`/stats/yearly`) - 5 tests
- Current and previous year totals
- Multiple years of data handling
- Empty years (returns zeros)
- Timezone boundary handling
- Meter-to-mile conversion

### Yearly Weekly Stats (`/stats/yearly-weekly`) - 7 tests
- 52 week buckets for 1-year period
- Custom periodEndDate parameter
- Defaults to today when periodEndDate not provided
- Workout distribution across buckets
- Empty periods handling
- Sparse data (single workout in year)
- Timezone offset support

### Available Periods (`/stats/available-periods`) - 5 tests
- Consecutive 1-year periods going backwards
- Stops at first workout date
- 20-period safety limit (allows 21 before stopping)
- Empty database handling
- Timezone offset for "today" calculation

### Available Years (`/stats/available-years`) - 4 tests
- Distinct years in descending order
- Multiple years handling
- Empty database (returns empty list)
- Single workout in year

### Best Efforts (`/stats/best-efforts`) - 2 tests
- Returns best efforts for standard distances
- Handles workouts without best efforts

### Recalculate Best Efforts (`/stats/best-efforts/recalculate`) - 2 tests
- Successfully recalculates all best efforts
- Handles empty database gracefully

## Fixture Data Helpers

- `SeedMultiYearWorkoutsAsync()`: Creates workouts across 2022-2025
- `SeedWorkoutsWithDifferentRunTypesAsync()`: Race, Workout, Easy Run, Long Run
- `SeedWorkoutsWithAndWithoutHRAsync()`: Mix with/without HR data
- `SeedWorkoutsWithSplitsAndRoutesAsync()`: Complete workout data
- `SeedSparseDataAsync()`: Single workout in a year
- `SeedCurrentWeekWorkoutsAsync()`: Workouts for current week
- `SeedPreviousWeeksWorkoutsAsync()`: Workouts for previous weeks

## Edge Cases

- Empty database: All endpoints return sensible defaults (zeros, empty arrays)
- Sparse data: Single workout in a year/week
- Missing optional fields: Workouts without HR, splits, routes
- Different run types: All types aggregated correctly
- Timezone handling: Tested with EST offset (-300 minutes)

## Test Statistics

- Total tests: 38
- File: `StatsEndpointsTests.cs` (~1,540 lines)
- All tests passing
- Follows existing test patterns and conventions

## Fixes

- Fixed `GetAvailablePeriods_Respects20PeriodSafetyLimit`: Updated expectation to <= 21 (endpoint adds period before checking count)
- Fixed `GetWeeklyStats_ConvertsMetersToMilesCorrectly`: Seed workout on today's date to ensure it's in current week, calculate correct day index

#84 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `StatsEndpointsTests.cs` with broad integration coverage for Stats APIs.
> 
> - Validates `/stats/weekly`, `/stats/yearly`, `/stats/yearly-weekly`, `/stats/relative-effort`, `/stats/available-periods`, `/stats/available-years`, `/stats/best-efforts`, and `/stats/best-efforts/recalculate`
> - Tests timezone offset handling, meter-to-mile conversion, 52-week bucketing, cumulative/average calculations, and available period/year ordering/limits
> - Covers empty/sparse datasets, different run types, and workouts with/without HR/time series
> - Includes reusable data seeding helpers for multi-year data and week-based scenarios
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 975c56a3b09982996171c18bfd072a7b92e42e0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->