### PR TITLE
feat(frontend): replace import alerts with inline success messages

### DIFF
--- a/frontend/components/FileUpload.tsx
+++ b/frontend/components/FileUpload.tsx
@@ -31,7 +31,11 @@ export function FileUpload() {
     onFilesSelected: (files) => {
       setSelectedFiles((prev) => [...prev, ...files]);
       setImportResult(null);
-      mutation.reset(); // Clear mutation error state when new files are selected
+      // Only reset mutation state if not currently pending to prevent re-enabling submit button
+      // during an in-flight upload, which could allow duplicate submissions
+      if (!mutation.isPending) {
+        mutation.reset(); // Clear mutation error state when new files are selected
+      }
     },
     acceptExtensions: ['.gpx', '.fit', '.fit.gz'],
   });


### PR DESCRIPTION
Replace browser alert popups with inline success and error messages in the FileUpload component for a better user experience.

- Remove all alert() calls for import feedback
- Add inline success messages for single file imports with workout details (distance, duration, pace, elevation) and navigation link
- Add inline success messages for multiple file imports with import summary (similar to BulkImport component)
- Display error messages inline instead of popups
- Clear success messages when new files are selected
- Style success messages consistently with BulkImport component

This provides a more seamless import experience without disruptive browser popups and allows users to easily navigate to imported workouts directly from the success message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves the import UX by surfacing inline results and errors instead of disruptive alerts.
> 
> - Adds inline success UI in `FileUpload` for both single-file (`WorkoutImportResponse`) and multi-file (`WorkoutImportSummaryResponse`) results, including formatted distance/duration/pace/elevation and a "View workout details" link
> - Shows inline error state via `mutation.isError`; removes all `alert()` calls
> - Persists import result in component state (`importResult`) and clears it when new files are selected; resets mutation state safely when not pending
> - Minor wiring: import `Link` and format helpers; keep query invalidation on success and clear selected files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6566d23df64b6161205c25a747d0f779bcac3e0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->