### PR TITLE
Add retired shoes: soft-hide from lists, retired mileage page, un-retire

### DIFF
--- a/api/Endpoints/SettingsEndpoints.cs
+++ b/api/Endpoints/SettingsEndpoints.cs
@@ -619,6 +619,11 @@ public static class SettingsEndpoints
                     return Results.NotFound(new { error = "Shoe not found" });
                 }
 
+                if (shoe.IsRetired)
+                {
+                    return Results.BadRequest(new { error = "Cannot set a retired shoe as the default shoe" });
+                }
+
                 settings.DefaultShoeId = request.DefaultShoeId.Value;
             }
             else

--- a/api/Endpoints/ShoesEndpoints.cs
+++ b/api/Endpoints/ShoesEndpoints.cs
@@ -11,20 +11,36 @@ namespace Tempo.Api.Endpoints;
 public static class ShoesEndpoints
 {
     /// <summary>
-    /// List all shoes with calculated mileage
+    /// List shoes with calculated mileage (active by default).
     /// </summary>
+    /// <param name="status">Filter: active (default), retired, or all</param>
     /// <param name="db">Database context</param>
     /// <param name="mileageService">Shoe mileage service</param>
     /// <param name="logger">Logger instance</param>
-    /// <returns>List of all shoes with total mileage</returns>
+    /// <returns>List of shoes with total mileage</returns>
     private static async Task<IResult> GetShoes(
+        string? status,
         TempoDbContext db,
         ShoeMileageService mileageService,
         ILogger<Program> logger)
     {
         try
         {
-            var shoes = await db.Shoes
+            var filter = (status ?? "active").Trim().ToLowerInvariant();
+            if (filter is not ("active" or "retired" or "all"))
+            {
+                return Results.BadRequest(new { error = "status must be active, retired, or all" });
+            }
+
+            var query = db.Shoes.AsQueryable();
+            query = filter switch
+            {
+                "active" => query.Where(s => !s.IsRetired),
+                "retired" => query.Where(s => s.IsRetired),
+                _ => query
+            };
+
+            var shoes = await query
                 .OrderBy(s => s.Brand)
                 .ThenBy(s => s.Model)
                 .ToListAsync();
@@ -43,6 +59,7 @@ public static class ShoesEndpoints
                     brand = shoe.Brand,
                     model = shoe.Model,
                     initialMileageM = shoe.InitialMileageM,
+                    isRetired = shoe.IsRetired,
                     totalMileage = totalMileage,
                     unit = unitPreference == "imperial" ? "miles" : "km",
                     createdAt = shoe.CreatedAt,
@@ -103,6 +120,7 @@ public static class ShoesEndpoints
                 Brand = request.Brand.Trim(),
                 Model = request.Model.Trim(),
                 InitialMileageM = request.InitialMileageM,
+                IsRetired = false,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow
             };
@@ -118,6 +136,7 @@ public static class ShoesEndpoints
                 brand = shoe.Brand,
                 model = shoe.Model,
                 initialMileageM = shoe.InitialMileageM,
+                isRetired = shoe.IsRetired,
                 createdAt = shoe.CreatedAt,
                 updatedAt = shoe.UpdatedAt
             });
@@ -259,6 +278,28 @@ public static class ShoesEndpoints
                 shoe.InitialMileageM = initialMileageValue;
             }
 
+            // Update IsRetired if provided
+            if (root.TryGetProperty("isRetired", out var isRetiredElement))
+            {
+                if (isRetiredElement.ValueKind != JsonValueKind.True && isRetiredElement.ValueKind != JsonValueKind.False)
+                {
+                    return Results.BadRequest(new { error = "isRetired must be a boolean" });
+                }
+
+                var newRetired = isRetiredElement.GetBoolean();
+                if (newRetired && !shoe.IsRetired)
+                {
+                    var settingsForRetire = await db.UserSettings.FirstOrDefaultAsync();
+                    if (settingsForRetire != null && settingsForRetire.DefaultShoeId == id)
+                    {
+                        settingsForRetire.DefaultShoeId = null;
+                        settingsForRetire.UpdatedAt = DateTime.UtcNow;
+                    }
+                }
+
+                shoe.IsRetired = newRetired;
+            }
+
             shoe.UpdatedAt = DateTime.UtcNow;
             await db.SaveChangesAsync();
 
@@ -270,6 +311,7 @@ public static class ShoesEndpoints
                 brand = shoe.Brand,
                 model = shoe.Model,
                 initialMileageM = shoe.InitialMileageM,
+                isRetired = shoe.IsRetired,
                 createdAt = shoe.CreatedAt,
                 updatedAt = shoe.UpdatedAt
             });
@@ -378,9 +420,10 @@ public static class ShoesEndpoints
         group.MapGet("", GetShoes)
             .WithName("GetShoes")
             .Produces(200)
+            .Produces(400)
             .Produces(500)
-            .WithSummary("List all shoes")
-            .WithDescription("Returns all shoes with calculated total mileage based on assigned workouts");
+            .WithSummary("List shoes")
+            .WithDescription("Returns shoes with calculated total mileage. Query status=active (default), retired, or all.");
 
         group.MapPost("", CreateShoe)
             .WithName("CreateShoe")
@@ -397,7 +440,7 @@ public static class ShoesEndpoints
             .Produces(404)
             .Produces(500)
             .WithSummary("Update a shoe")
-            .WithDescription("Updates shoe brand, model, and/or initial mileage");
+            .WithDescription("Updates shoe brand, model, initial mileage, and/or isRetired");
 
         group.MapDelete("/{id:guid}", DeleteShoe)
             .WithName("DeleteShoe")
@@ -456,6 +499,11 @@ public static class ShoesEndpoints
         /// Initial mileage in meters (optional)
         /// </summary>
         public double? InitialMileageM { get; set; }
+
+        /// <summary>
+        /// Whether the shoe is retired (optional)
+        /// </summary>
+        public bool? IsRetired { get; set; }
     }
 }
 

--- a/api/Endpoints/WorkoutsEndpoints.cs
+++ b/api/Endpoints/WorkoutsEndpoints.cs
@@ -1556,7 +1556,7 @@ public static class WorkoutsEndpoints
             {
                 // Verify the shoe still exists
                 var defaultShoe = await db.Shoes.FindAsync(settings.DefaultShoeId.Value);
-                if (defaultShoe != null)
+                if (defaultShoe != null && !defaultShoe.IsRetired)
                 {
                     foreach (var workout in workoutsToAdd)
                     {
@@ -2088,6 +2088,11 @@ public static class WorkoutsEndpoints
                     if (shoe == null)
                     {
                         return Results.BadRequest(new { error = "Shoe not found" });
+                    }
+
+                    if (shoe.IsRetired)
+                    {
+                        return Results.BadRequest(new { error = "Cannot assign a retired shoe to a workout" });
                     }
                 }
                 else
@@ -3264,7 +3269,7 @@ public static class WorkoutsEndpoints
             {
                 // Verify the shoe still exists
                 var defaultShoe = await db.Shoes.FindAsync(settings.DefaultShoeId.Value);
-                if (defaultShoe != null)
+                if (defaultShoe != null && !defaultShoe.IsRetired)
                 {
                     workout.ShoeId = settings.DefaultShoeId.Value;
                     logger.LogInformation("Assigned default shoe {ShoeId} to workout {WorkoutId}", settings.DefaultShoeId.Value, workout.Id);

--- a/api/Migrations/20260429231609_AddShoeIsRetired.Designer.cs
+++ b/api/Migrations/20260429231609_AddShoeIsRetired.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tempo.Api.Data;
@@ -11,9 +12,11 @@ using Tempo.Api.Data;
 namespace Tempo.Api.Migrations
 {
     [DbContext(typeof(TempoDbContext))]
-    partial class TempoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429231609_AddShoeIsRetired")]
+    partial class AddShoeIsRetired
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20260429231609_AddShoeIsRetired.cs
+++ b/api/Migrations/20260429231609_AddShoeIsRetired.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tempo.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddShoeIsRetired : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsRetired",
+                table: "Shoes",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsRetired",
+                table: "Shoes");
+        }
+    }
+}

--- a/api/Models/Shoe.cs
+++ b/api/Models/Shoe.cs
@@ -23,6 +23,8 @@ public class Shoe
 
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 
+    public bool IsRetired { get; set; }
+
     // Navigation properties
     public ICollection<Workout> Workouts { get; set; } = new List<Workout>();
 }

--- a/api/Services/DatabaseMigrationHelper.cs
+++ b/api/Services/DatabaseMigrationHelper.cs
@@ -44,7 +44,8 @@ public static class DatabaseMigrationHelper
         { ("UserSettings", "UnitPreference"), "20251127020615_AddUnitPreferenceToUserSettings" },
         // AddShoeTracking migration
         { ("Workouts", "ShoeId"), "20251201120000_AddShoeTracking" },
-        { ("UserSettings", "DefaultShoeId"), "20251201120000_AddShoeTracking" }
+        { ("UserSettings", "DefaultShoeId"), "20251201120000_AddShoeTracking" },
+        { ("Shoes", "IsRetired"), "20260429231609_AddShoeIsRetired" }
     };
 
     private const string ProductVersion = "9.0.10";

--- a/api/Services/ImportService.cs
+++ b/api/Services/ImportService.cs
@@ -343,13 +343,22 @@ public class ImportService
                 existing.Zone5MaxBpm = settings.Zone5MaxBpm;
                 existing.UnitPreference = settings.UnitPreference;
                 
-                // Validate shoe reference if present
+                // Validate shoe reference if present (must exist and not be retired)
                 if (settings.DefaultShoeId.HasValue)
                 {
-                    var shoeExists = await _db.Shoes.AnyAsync(s => s.Id == settings.DefaultShoeId.Value);
-                    if (!shoeExists)
+                    var id = settings.DefaultShoeId.Value;
+                    var validDefault = await _db.Shoes.AnyAsync(s => s.Id == id && !s.IsRetired);
+                    if (!validDefault)
                     {
-                        result.Warnings.Add($"Settings references non-existent shoe {settings.DefaultShoeId}, clearing reference");
+                        if (await _db.Shoes.AnyAsync(s => s.Id == id && s.IsRetired))
+                        {
+                            result.Warnings.Add($"Settings references retired shoe {settings.DefaultShoeId}, clearing reference");
+                        }
+                        else
+                        {
+                            result.Warnings.Add($"Settings references non-existent shoe {settings.DefaultShoeId}, clearing reference");
+                        }
+
                         existing.DefaultShoeId = null;
                     }
                     else
@@ -380,13 +389,22 @@ public class ImportService
             }
             else
             {
-                // Validate shoe reference if present
+                // Validate shoe reference if present (must exist and not be retired)
                 if (settings.DefaultShoeId.HasValue)
                 {
-                    var shoeExists = await _db.Shoes.AnyAsync(s => s.Id == settings.DefaultShoeId.Value);
-                    if (!shoeExists)
+                    var id = settings.DefaultShoeId.Value;
+                    var validDefault = await _db.Shoes.AnyAsync(s => s.Id == id && !s.IsRetired);
+                    if (!validDefault)
                     {
-                        result.Warnings.Add($"Settings references non-existent shoe {settings.DefaultShoeId}, clearing reference");
+                        if (await _db.Shoes.AnyAsync(s => s.Id == id && s.IsRetired))
+                        {
+                            result.Warnings.Add($"Settings references retired shoe {settings.DefaultShoeId}, clearing reference");
+                        }
+                        else
+                        {
+                            result.Warnings.Add($"Settings references non-existent shoe {settings.DefaultShoeId}, clearing reference");
+                        }
+
                         settings.DefaultShoeId = null;
                     }
                 }

--- a/api/Tempo.Api.Tests/Infrastructure/TestDataSeeder.cs
+++ b/api/Tempo.Api.Tests/Infrastructure/TestDataSeeder.cs
@@ -44,18 +44,21 @@ public static class TestDataSeeder
     /// <param name="brand">Shoe brand (default: "Nike")</param>
     /// <param name="model">Shoe model (default: "Pegasus")</param>
     /// <param name="initialMileage">Initial mileage in meters (optional)</param>
+    /// <param name="isRetired">Whether the shoe is retired (default: false)</param>
     /// <returns>Created Shoe entity</returns>
     public static async Task<Shoe> SeedShoeAsync(
         TempoDbContext db,
         string brand = "Nike",
         string model = "Pegasus",
-        double? initialMileage = null)
+        double? initialMileage = null,
+        bool isRetired = false)
     {
         var shoe = new Shoe
         {
             Brand = brand,
             Model = model,
             InitialMileageM = initialMileage,
+            IsRetired = isRetired,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow
         };

--- a/api/Tempo.Api.Tests/IntegrationTests/ShoesEndpointsTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/ShoesEndpointsTests.cs
@@ -64,6 +64,81 @@ public class ShoesEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         result[0].brand.Should().Be("Adidas"); // Sorted by brand
         result[1].brand.Should().Be("Nike");
         result[1].totalMileage.Should().BeApproximately(6.0, 0.001); // 1km initial + 5km workout = 6km
+        result.Should().OnlyContain(s => !s.isRetired);
+    }
+
+    [Fact]
+    public async Task GetShoes_StatusActive_ExcludesRetiredShoes()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            await TestDataSeeder.SeedShoeAsync(db, "Active", "One");
+            await TestDataSeeder.SeedShoeAsync(db, "Retired", "Two", isRetired: true);
+        }
+
+        var response = await client.GetAsync("/shoes");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<List<ShoeResponse>>();
+        result.Should().NotBeNull();
+        result!.Should().HaveCount(1);
+        result[0].brand.Should().Be("Active");
+    }
+
+    [Fact]
+    public async Task GetShoes_StatusRetired_ReturnsOnlyRetiredShoes()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            await TestDataSeeder.SeedShoeAsync(db, "Active", "One");
+            await TestDataSeeder.SeedShoeAsync(db, "Retired", "Two", isRetired: true);
+        }
+
+        var response = await client.GetAsync("/shoes?status=retired");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<List<ShoeResponse>>();
+        result.Should().NotBeNull();
+        result!.Should().HaveCount(1);
+        result[0].brand.Should().Be("Retired");
+        result[0].isRetired.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetShoes_StatusAll_ReturnsActiveAndRetired()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            await TestDataSeeder.SeedShoeAsync(db, "A", "One");
+            await TestDataSeeder.SeedShoeAsync(db, "B", "Two", isRetired: true);
+        }
+
+        var response = await client.GetAsync("/shoes?status=all");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<List<ShoeResponse>>();
+        result.Should().NotBeNull();
+        result!.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetShoes_InvalidStatus_ReturnsBadRequest()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        var response = await client.GetAsync("/shoes?status=invalid");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
@@ -103,6 +178,7 @@ public class ShoesEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         result.model.Should().Be("Pegasus 40");
         result.initialMileageM.Should().Be(1000.0);
         result.id.Should().NotBeEmpty();
+        result.isRetired.Should().BeFalse();
     }
 
     [Fact]
@@ -307,6 +383,54 @@ public class ShoesEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         result!.brand.Should().Be("Nike"); // Unchanged
         result.model.Should().Be("Pegasus 40"); // Updated
         result.initialMileageM.Should().Be(1000.0); // Unchanged
+    }
+
+    [Fact]
+    public async Task UpdateShoe_SetIsRetired_ClearsDefaultShoe()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Shoe shoe;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            shoe = await TestDataSeeder.SeedShoeAsync(db, "Nike", "Pegasus");
+            await TestDataSeeder.SeedUserSettingsAsync(db, defaultShoeId: shoe.Id);
+        }
+
+        var response = await client.PatchAsJsonAsync($"/shoes/{shoe.Id}", new { isRetired = true });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<ShoeResponse>();
+        body.Should().NotBeNull();
+        body!.isRetired.Should().BeTrue();
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            var settings = await db.UserSettings.FirstOrDefaultAsync();
+            settings.Should().NotBeNull();
+            settings!.DefaultShoeId.Should().BeNull();
+        }
+    }
+
+    [Fact]
+    public async Task SetDefaultShoe_WithRetiredShoe_ReturnsBadRequest()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Shoe shoe;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            shoe = await TestDataSeeder.SeedShoeAsync(db, "Nike", "Old", isRetired: true);
+        }
+
+        var response = await client.PutAsJsonAsync("/settings/default-shoe", new { defaultShoeId = shoe.Id });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
@@ -544,6 +668,7 @@ public class ShoesEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         public string brand { get; set; } = string.Empty;
         public string model { get; set; } = string.Empty;
         public double? initialMileageM { get; set; }
+        public bool isRetired { get; set; }
         public double totalMileage { get; set; }
         public string unit { get; set; } = string.Empty;
         public DateTime createdAt { get; set; }

--- a/api/Tempo.Api.Tests/IntegrationTests/WorkoutDetailsUpdateDeleteTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/WorkoutDetailsUpdateDeleteTests.cs
@@ -384,6 +384,29 @@ public class WorkoutDetailsUpdateDeleteTests : IClassFixture<TempoWebApplication
     }
 
     [Fact]
+    public async Task UpdateWorkout_Returns400_WhenShoeIsRetired()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Workout workout;
+        Shoe shoe;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            workout = await TestDataSeeder.SeedWorkoutAsync(db);
+            shoe = await TestDataSeeder.SeedShoeAsync(db, brand: "Nike", model: "Old", isRetired: true);
+        }
+
+        var updateRequest = new { shoeId = shoe.Id.ToString() };
+        var content = new StringContent(JsonSerializer.Serialize(updateRequest), Encoding.UTF8, "application/json");
+
+        var response = await client.PatchAsync($"/workouts/{workout.Id}", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task UpdateWorkout_RemovesShoeAssignment_WhenShoeIdIsNull()
     {
         // Arrange

--- a/api/Tempo.Api.Tests/Services/ExportServiceTests.cs
+++ b/api/Tempo.Api.Tests/Services/ExportServiceTests.cs
@@ -379,6 +379,31 @@ public class ExportServiceTests : IClassFixture<TempoWebApplicationFactory>, IDi
     /// <summary>
     /// Cleans the database before a test to ensure accurate statistics
     /// </summary>
+    [Fact]
+    public async Task ExportAllDataAsync_ShoesJsonIncludesIsRetired()
+    {
+        await CleanDatabaseAsync();
+        await TestDataSeeder.SeedShoeAsync(_db, "Nike", "Active");
+        await TestDataSeeder.SeedShoeAsync(_db, "Adidas", "Retired", isRetired: true);
+
+        using var zipStream = new MemoryStream();
+        await _exportService.ExportAllDataAsync(zipStream);
+        zipStream.Position = 0;
+
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        var shoesEntry = archive.GetEntry("data/shoes.json");
+        shoesEntry.Should().NotBeNull();
+        using var shoesStream = shoesEntry!.Open();
+        var shoesJson = await new StreamReader(shoesStream).ReadToEndAsync();
+        var shoes = JsonSerializer.Deserialize<List<JsonElement>>(shoesJson);
+        shoes.Should().NotBeNull();
+        shoes!.Should().HaveCount(2);
+        var retired = shoes.Single(e => e.GetProperty("brand").GetString() == "Adidas");
+        retired.GetProperty("isRetired").GetBoolean().Should().BeTrue();
+        var active = shoes.Single(e => e.GetProperty("brand").GetString() == "Nike");
+        active.GetProperty("isRetired").GetBoolean().Should().BeFalse();
+    }
+
     private async Task CleanDatabaseAsync()
     {
         // Delete in order to respect foreign key constraints

--- a/frontend/app/dashboard/[id]/page.tsx
+++ b/frontend/app/dashboard/[id]/page.tsx
@@ -349,6 +349,7 @@ function WorkoutDetailPageContent() {
                     <div className="flex items-center gap-2">
                       <ShoeSelector
                         value={data.shoeId}
+                        assignedShoe={data.shoe}
                         onChange={(shoeId) => {
                           updateWorkoutMutation.mutate(
                             { shoeId },

--- a/frontend/app/settings/shoes/retired/page.tsx
+++ b/frontend/app/settings/shoes/retired/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import Link from 'next/link';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getShoes, updateShoe } from '@/lib/api';
+import { AuthGuard } from '@/components/AuthGuard';
+
+function RetiredShoesContent() {
+  const queryClient = useQueryClient();
+  const { data: shoes, isLoading } = useQuery({
+    queryKey: ['shoes', 'retired'],
+    queryFn: () => getShoes({ status: 'retired' }),
+  });
+
+  const unretireMutation = useMutation({
+    mutationFn: (id: string) => updateShoe(id, { isRetired: false }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['shoes'] });
+      queryClient.invalidateQueries({ queryKey: ['default-shoe'] });
+    },
+  });
+
+  return (
+    <div className="flex min-h-screen items-start justify-center bg-zinc-50 dark:bg-black">
+      <main className="flex min-h-screen w-full max-w-4xl flex-col items-start py-16 px-8">
+        <div className="w-full mb-8">
+          <p className="mb-2">
+            <Link
+              href="/settings"
+              className="text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+            >
+              ← Back to Settings
+            </Link>
+          </p>
+          <h1 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-2">Retired shoes</h1>
+          <p className="text-lg text-gray-600 dark:text-gray-400">
+            Shoes you retired stay here with their mileage. Un-retire to use them in lists again.
+          </p>
+        </div>
+
+        <div className="w-full bg-white dark:bg-gray-900 p-6 rounded-lg border border-gray-200 dark:border-gray-800">
+          {isLoading ? (
+            <p className="text-gray-600 dark:text-gray-400">Loading…</p>
+          ) : !shoes?.length ? (
+            <p className="text-gray-600 dark:text-gray-400">No retired shoes.</p>
+          ) : (
+            <ul className="space-y-4">
+              {shoes.map((shoe) => (
+                <li
+                  key={shoe.id}
+                  className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
+                >
+                  <div>
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                      {shoe.brand} {shoe.model}
+                    </h2>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      Total: {shoe.totalMileage.toFixed(1)} {shoe.unit}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => unretireMutation.mutate(shoe.id)}
+                    disabled={unretireMutation.isPending}
+                    className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 disabled:opacity-50 shrink-0"
+                  >
+                    {unretireMutation.isPending ? 'Saving…' : 'Un-retire'}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default function RetiredShoesPage() {
+  return (
+    <AuthGuard>
+      <RetiredShoesContent />
+    </AuthGuard>
+  );
+}

--- a/frontend/components/ShoeManagementSection.tsx
+++ b/frontend/components/ShoeManagementSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getShoes,
@@ -50,8 +51,8 @@ export function ShoeManagementSection() {
   };
 
   const { data: shoes, isLoading } = useQuery({
-    queryKey: ['shoes'],
-    queryFn: getShoes,
+    queryKey: ['shoes', 'active'],
+    queryFn: () => getShoes({ status: 'active' }),
   });
 
   const { data: defaultShoe } = useQuery({
@@ -120,6 +121,16 @@ export function ShoeManagementSection() {
     }
   };
 
+  const handleRetire = (id: string) => {
+    if (
+      window.confirm(
+        'Retire this shoe? It will no longer appear in lists or as an option for new workouts. Past workouts keep their assignment. You can un-retire it later from Retired shoes.'
+      )
+    ) {
+      updateMutation.mutate({ id, data: { isRetired: true } });
+    }
+  };
+
   const handleSetDefault = (id: string | null) => {
     setDefaultMutation.mutate(id);
   };
@@ -155,8 +166,16 @@ export function ShoeManagementSection() {
       <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
         Shoe Management
       </h2>
-      <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+      <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">
         Track mileage on your running shoes. Assign shoes to workouts to automatically calculate total mileage.
+      </p>
+      <p className="text-sm mb-6">
+        <Link
+          href="/settings/shoes/retired"
+          className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 underline"
+        >
+          View retired shoes and mileage
+        </Link>
       </p>
 
       {/* Default Shoe Selector */}
@@ -338,12 +357,20 @@ export function ShoeManagementSection() {
                         </span>
                       )}
                     </div>
-                    <div className="flex gap-2">
+                    <div className="flex flex-wrap gap-2 justify-end">
                       <button
                         onClick={() => startEdit(shoe)}
                         className="px-3 py-1 text-sm bg-gray-200 text-gray-700 rounded hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
                       >
                         Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleRetire(shoe.id)}
+                        disabled={updateMutation.isPending}
+                        className="px-3 py-1 text-sm bg-amber-100 text-amber-900 rounded hover:bg-amber-200 dark:bg-amber-900/40 dark:text-amber-100 dark:hover:bg-amber-900/60 disabled:opacity-50"
+                      >
+                        Retire
                       </button>
                       <button
                         onClick={() => handleDelete(shoe.id)}

--- a/frontend/components/ShoeManagementSection.tsx
+++ b/frontend/components/ShoeManagementSection.tsx
@@ -71,12 +71,23 @@ export function ShoeManagementSection() {
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: UpdateShoeRequest }) => updateShoe(id, data),
-    onSuccess: () => {
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: UpdateShoeRequest;
+      /** When false, leave the edit form open (e.g. retiring a different shoe than the one being edited). */
+      resetEditForm?: boolean;
+    }) => updateShoe(id, data),
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['shoes'] });
       queryClient.invalidateQueries({ queryKey: ['default-shoe'] });
-      setEditingId(null);
-      setEditShoe({ brand: '', model: '', initialMileageM: null });
+      if (variables.resetEditForm !== false) {
+        setEditingId(null);
+        setEditShoe({ brand: '', model: '', initialMileageM: null });
+        setEditShoeInitialMileageInput('');
+      }
     },
   });
 
@@ -127,7 +138,7 @@ export function ShoeManagementSection() {
         'Retire this shoe? It will no longer appear in lists or as an option for new workouts. Past workouts keep their assignment. You can un-retire it later from Retired shoes.'
       )
     ) {
-      updateMutation.mutate({ id, data: { isRetired: true } });
+      updateMutation.mutate({ id, data: { isRetired: true }, resetEditForm: false });
     }
   };
 

--- a/frontend/components/ShoeSelector.tsx
+++ b/frontend/components/ShoeSelector.tsx
@@ -8,12 +8,14 @@ interface ShoeSelectorProps {
   onChange: (shoeId: string | null) => void;
   showMileage?: boolean;
   className?: string;
+  /** When the workout is assigned a retired shoe, pass it so the select can show the current value. */
+  assignedShoe?: { id: string; brand: string; model: string } | null;
 }
 
-export function ShoeSelector({ value, onChange, showMileage = false, className = '' }: ShoeSelectorProps) {
+export function ShoeSelector({ value, onChange, showMileage = false, className = '', assignedShoe = null }: ShoeSelectorProps) {
   const { data: shoes, isLoading } = useQuery({
-    queryKey: ['shoes'],
-    queryFn: getShoes,
+    queryKey: ['shoes', 'active'],
+    queryFn: () => getShoes({ status: 'active' }),
   });
 
   if (isLoading) {
@@ -31,6 +33,12 @@ export function ShoeSelector({ value, onChange, showMileage = false, className =
     return `${shoe.brand} ${shoe.model}`;
   };
 
+  const showRetiredAssigned =
+    !!value &&
+    !!assignedShoe &&
+    assignedShoe.id === value &&
+    !shoes?.some((s) => s.id === value);
+
   return (
     <select
       value={value || ''}
@@ -38,6 +46,11 @@ export function ShoeSelector({ value, onChange, showMileage = false, className =
       className={className}
     >
       <option value="">None</option>
+      {showRetiredAssigned && assignedShoe && (
+        <option key={assignedShoe.id} value={assignedShoe.id}>
+          {assignedShoe.brand} {assignedShoe.model} (retired)
+        </option>
+      )}
       {shoes?.map((shoe) => (
         <option key={shoe.id} value={shoe.id}>
           {formatShoeLabel(shoe)}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1128,6 +1128,7 @@ export interface Shoe {
   brand: string;
   model: string;
   initialMileageM: number | null;
+  isRetired: boolean;
   totalMileage: number;
   unit: 'km' | 'miles';
   createdAt: string;
@@ -1152,6 +1153,7 @@ export interface UpdateShoeRequest {
   brand?: string;
   model?: string;
   initialMileageM?: number | null;
+  isRetired?: boolean;
 }
 
 export interface ShoeMileageResponse {
@@ -1166,16 +1168,22 @@ export interface DefaultShoeResponse {
   model?: string;
 }
 
+export type ShoesListStatus = 'active' | 'retired' | 'all';
+
 // Shoe API functions
-export async function getShoes(): Promise<Shoe[]> {
-  const response = await fetchWithAuth(`${API_BASE_URL}/shoes`, {
+export async function getShoes(params?: { status?: ShoesListStatus }): Promise<Shoe[]> {
+  const status = params?.status ?? 'active';
+  const qs = new URLSearchParams({ status });
+  const response = await fetchWithAuth(`${API_BASE_URL}/shoes?${qs.toString()}`, {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch shoes: ${response.status}`);
+    const err = await response.json().catch(() => null);
+    const msg = err && typeof err === 'object' && 'error' in err ? String((err as { error: string }).error) : `Failed to fetch shoes: ${response.status}`;
+    throw new Error(msg);
   }
 
   return response.json();


### PR DESCRIPTION
### Summary

Adds **soft retirement** for running shoes so users can hide pairs they no longer use while keeping history on past workouts. Retired shoes are excluded from default lists and from picking a default shoe or assigning a shoe on workout edit, with a dedicated settings view for mileage and **un-retire**.

### Backend

- **`Shoe.IsRetired`** with EF migration (`AddShoeIsRetired`); existing rows default to not retired.
- **`GET /shoes`**: optional `status` query (`active` default, `retired`, `all`); list payloads include `isRetired`.
- **`PATCH /shoes/{id}`**: accepts `isRetired`; retiring clears **`UserSettings.DefaultShoeId`** when it points at that shoe.
- **`PUT /settings/default-shoe`**: rejects retired shoes (**400**).
- **Imports**: default shoe is only applied if the shoe exists and is not retired; bulk and single-import paths respect the same rule.
- **Workout PATCH**: cannot assign a retired shoe (**400**); existing `ShoeId` on old workouts unchanged.
- **Full export**: `isRetired` is included in `data/shoes.json` for backup round-trip.

### Frontend

- Active shoes only in settings management and shoe picker; **Retire** with confirmation vs delete.
- Link to **`/settings/shoes/retired`**: list retired shoes with total mileage and **Un-retire**.
- **`ShoeSelector`**: optional **`assignedShoe`** so workouts still tied to a retired shoe show a stable “(retired)” option when editing.

### Tests

- Integration coverage for shoe list filters, retire clearing default, default shoe on retired shoe, workout assign retired shoe, and export JSON including `isRetired`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core workout/shoe assignment paths, adds new validation rules, and introduces a DB migration; main risk is behavior changes that could unexpectedly block updates or clear defaults if clients rely on previously-allowed shoe IDs.
> 
> **Overview**
> Adds *soft-retirement* for shoes by introducing `Shoe.IsRetired` (EF migration) and propagating the flag through shoe APIs/responses.
> 
> Backend now filters `GET /shoes` by `status` (`active` default, `retired`, `all`), allows toggling retirement via `PATCH /shoes/{id}`, blocks using retired shoes as the default shoe or as a workout assignment, and prevents auto-assigning a retired default shoe to new workouts; retiring a shoe also clears `UserSettings.DefaultShoeId` when applicable, and import/export paths preserve/validate this state.
> 
> Frontend updates shoe fetching to request only active shoes by default, adds a retire action and a new `/settings/shoes/retired` page to view mileage and un-retire, and enhances `ShoeSelector` to still display a currently-assigned retired shoe while preventing new selection of retired shoes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b161ea5ca9c365db28346fee840fdb42b3fcd65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->