### PR TITLE
feat: add Garmin product mapping to DeviceExtractionService

### DIFF
--- a/api/Services/DeviceExtractionService.cs
+++ b/api/Services/DeviceExtractionService.cs
@@ -7,6 +7,19 @@ namespace Tempo.Api.Services;
 /// </summary>
 public static class DeviceExtractionService
 {
+    private static readonly IReadOnlyDictionary<ushort, string> GarminProductMap = new Dictionary<ushort, string>
+    {
+        // Source: FIT SDK GarminProduct constants
+        // Keep this list focused and expand over time as we encounter new devices.
+        { 3113, "Garmin Forerunner 945" },      // Fr945
+        { 3652, "Garmin Forerunner 945 LTE" },  // Fr945Lte
+        { 4024, "Garmin Forerunner 955" },      // Fr955
+        { 4315, "Garmin Forerunner 965" },      // Fr965
+        { 3905, "Garmin Fenix 7S" },            // Fenix7s
+        { 3906, "Garmin Fenix 7" },             // Fenix7
+        { 3907, "Garmin Fenix 7X" }             // Fenix7x
+    };
+
     /// <summary>
     /// Maps Apple Watch identifiers to friendly device names.
     /// Based on AppleDB device information: https://appledb.dev/device-selection/Apple-Watch.html
@@ -255,9 +268,14 @@ public static class DeviceExtractionService
         // Combine manufacturer and product code
         if (!string.IsNullOrWhiteSpace(manufacturer) && productCode.HasValue)
         {
+            if (manufacturer.Equals("Garmin", StringComparison.OrdinalIgnoreCase) &&
+                GarminProductMap.TryGetValue(productCode.Value, out var garminModel))
+            {
+                return garminModel;
+            }
+
             // For known manufacturers, show manufacturer name
-            // For Garmin, we could map product codes, but that's extensive
-            // For now, show manufacturer name (cleaner than "Garmin 108")
+            // For Garmin unknown product IDs, fall back to manufacturer name.
             return manufacturer;
         }
 

--- a/api/Tempo.Api.Tests/Services/DeviceExtractionServiceTests.cs
+++ b/api/Tempo.Api.Tests/Services/DeviceExtractionServiceTests.cs
@@ -130,7 +130,7 @@ public class DeviceExtractionServiceTests
         var json = JsonSerializer.Serialize(new
         {
             manufacturer = 1, // Garmin
-            product = 1234
+            product = 9999
         });
         var element = JsonSerializer.Deserialize<JsonElement>(json);
 
@@ -138,8 +138,44 @@ public class DeviceExtractionServiceTests
         var result = DeviceExtractionService.ExtractDeviceName(element, _loggerMock.Object);
 
         // Assert
-        result.Should().NotBeNull();
-        result.Should().Contain("Garmin");
+        result.Should().Be("Garmin");
+    }
+
+    [Fact]
+    public void ExtractDeviceName_WithGarminKnownProductCode_ReturnsFriendlyModelName()
+    {
+        // Arrange
+        var json = JsonSerializer.Serialize(new
+        {
+            manufacturer = 1, // Garmin
+            product = 4315 // Fr965
+        });
+        var element = JsonSerializer.Deserialize<JsonElement>(json);
+
+        // Act
+        var result = DeviceExtractionService.ExtractDeviceName(element, _loggerMock.Object);
+
+        // Assert
+        result.Should().Be("Garmin Forerunner 965");
+    }
+
+    [Fact]
+    public void ExtractDeviceName_WithProductNameAndGarminProductCode_PrefersProductName()
+    {
+        // Arrange
+        var json = JsonSerializer.Serialize(new
+        {
+            productName = "Custom Garmin Name",
+            manufacturer = 1, // Garmin
+            product = 4315 // Fr965
+        });
+        var element = JsonSerializer.Deserialize<JsonElement>(json);
+
+        // Act
+        var result = DeviceExtractionService.ExtractDeviceName(element, _loggerMock.Object);
+
+        // Assert
+        result.Should().Be("Custom Garmin Name");
     }
 
     [Fact]


### PR DESCRIPTION
- Introduced a dictionary to map Garmin product codes to friendly device names.
- Enhanced ExtractDeviceName method to return friendly names for known Garmin products.
- Updated unit tests to cover new Garmin product mappings and ensure correct functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to device-name formatting logic and unit tests, with a small, deterministic lookup table and safe fallback behavior for unknown Garmin product IDs.
> 
> **Overview**
> **Improves Garmin device name extraction from FIT files** by adding a small `GarminProductMap` and returning friendly model names when the manufacturer is Garmin and the product ID is recognized.
> 
> For unknown Garmin product IDs, the service now explicitly falls back to returning just `"Garmin"` rather than embedding the numeric product code. Tests were updated to cover known/unknown Garmin product IDs and to confirm `productName` still takes precedence over manufacturer/product mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6e5068d90808a70341779a483a04652ec21911a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->