### PR TITLE
feat: add paginated heart-rate time series endpoint for workouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,14 @@ That's it! The database migrations run automatically on first startup. For detai
 **OpenAPI:** The canonical HTTP API contract for tools and client generation (including the planned read-only CLI) is **[docs/openapi.json](docs/openapi.json)** on the default integration branch (`develop`). After changing routes or Swagger metadata, regenerate it: run `dotnet tool restore` once at the repo root, then:
 
 ```bash
-cd api && dotnet build -c Release \
+cd api && dotnet build \
   && ASPNETCORE_ENVIRONMENT=Development \
      JWT__SecretKey='local-openapi-only-not-for-production-min-32-chars!' \
      ConnectionStrings__DefaultConnection='Data Source=:memory:' \
-     dotnet swagger tofile --output ../docs/openapi.json bin/Release/net9.0/Tempo.Api.dll v1
+     dotnet swagger tofile --output ../docs/openapi.json bin/Debug/net9.0/Tempo.Api.dll v1
 ```
+
+Use the **Debug** output assembly (`bin/Debug/...`) so the file matches **CI**, which runs `dotnet swagger tofile` against `bin/Debug/net9.0/Tempo.Api.dll` after `dotnet build Tempo.sln`.
 
 Use **Development** (not `Testing`) for `dotnet swagger tofile`: with `Testing`, the generic host looks for a `StartupTesting` class that this app does not ship, and Swashbuckle fails. In-memory SQLite avoids needing Postgres for this one-off export.
 

--- a/api/Endpoints/WorkoutsEndpoints.cs
+++ b/api/Endpoints/WorkoutsEndpoints.cs
@@ -14,6 +14,9 @@ namespace Tempo.Api.Endpoints;
 
 public static class WorkoutsEndpoints
 {
+    private const int TimeSeriesDefaultPageSize = 1000;
+    private const int TimeSeriesMaxPageSize = 5000;
+
     // Result class for file processing
     private class FileProcessResult
     {
@@ -1313,6 +1316,69 @@ public static class WorkoutsEndpoints
     }
 
     /// <summary>
+    /// Paginated heart-rate samples for a workout (from stored time series).
+    /// </summary>
+    private static async Task<IResult> GetWorkoutTimeSeries(
+        Guid id,
+        TempoDbContext db,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = TimeSeriesDefaultPageSize)
+    {
+        var workoutExists = await db.Workouts.AsNoTracking().AnyAsync(w => w.Id == id);
+        if (!workoutExists)
+        {
+            return Results.NotFound(new { error = "Workout not found" });
+        }
+
+        if (page < 1)
+        {
+            page = 1;
+        }
+
+        if (pageSize < 1)
+        {
+            pageSize = TimeSeriesDefaultPageSize;
+        }
+
+        if (pageSize > TimeSeriesMaxPageSize)
+        {
+            pageSize = TimeSeriesMaxPageSize;
+        }
+
+        var query = db.WorkoutTimeSeries.AsNoTracking()
+            .Where(ts => ts.WorkoutId == id && ts.HeartRateBpm != null)
+            .OrderBy(ts => ts.ElapsedSeconds)
+            .ThenBy(ts => ts.Id);
+
+        var totalCount = await query.CountAsync();
+        var totalPages = (int)Math.Ceiling(totalCount / (double)pageSize);
+
+        if (page > totalPages && totalPages > 0)
+        {
+            return Results.NotFound(new { error = "Page not found" });
+        }
+
+        var rows = await query
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(ts => new
+            {
+                elapsedSeconds = ts.ElapsedSeconds,
+                heartRateBpm = (int)ts.HeartRateBpm!.Value
+            })
+            .ToListAsync();
+
+        return Results.Ok(new
+        {
+            items = rows,
+            page,
+            pageSize,
+            totalCount,
+            totalPages
+        });
+    }
+
+    /// <summary>
     /// Get similar routes for a workout
     /// </summary>
     /// <param name="id">Workout ID</param>
@@ -2364,6 +2430,18 @@ public static class WorkoutsEndpoints
         .Produces(404)
         .WithSummary("Get similar routes")
         .WithDescription("Returns previous workouts that were completed on similar routes, allowing users to compare their current performance with past efforts. Includes time and pace differences compared to the current workout. Requires the workout to have route data.");
+
+        group.MapGet("/{id:guid}/time-series", GetWorkoutTimeSeries)
+        .WithName("GetWorkoutTimeSeries")
+        .Produces(200)
+        .Produces(404)
+        .WithSummary("Get workout heart-rate time series")
+        .WithDescription(
+            "Returns paginated heart-rate samples from stored workout time series. Each item has elapsedSeconds (integer seconds from workout start) and heartRateBpm (integer). " +
+            "Samples are sparse: only timestamps where heart rate was recorded are included (not a dense sample for every second). GPX imports may be sparse; FIT files are often about one sample per second but not guaranteed. " +
+            "The server does not interpolate missing seconds; clients may interpolate if needed. " +
+            "Ordering is ascending by elapsedSeconds, then by row id when multiple samples share the same second. " +
+            $"Default pageSize is {TimeSeriesDefaultPageSize} with a maximum of {TimeSeriesMaxPageSize}; use multiple requests for long activities.");
 
         group.MapGet("/{id:guid}", GetWorkout)
         .WithName("GetWorkout")

--- a/api/Endpoints/WorkoutsEndpoints.cs
+++ b/api/Endpoints/WorkoutsEndpoints.cs
@@ -1353,7 +1353,9 @@ public static class WorkoutsEndpoints
         var totalCount = await query.CountAsync();
         var totalPages = (int)Math.Ceiling(totalCount / (double)pageSize);
 
-        if (page > totalPages && totalPages > 0)
+        // When totalPages is 0 (no samples), only page 1 is valid; larger pages are out of range.
+        var pageOutOfRange = totalPages > 0 ? page > totalPages : page > 1;
+        if (pageOutOfRange)
         {
             return Results.NotFound(new { error = "Page not found" });
         }

--- a/api/Tempo.Api.Tests/IntegrationTests/WorkoutTimeSeriesEndpointTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/WorkoutTimeSeriesEndpointTests.cs
@@ -1,0 +1,212 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Tempo.Api.Data;
+using Tempo.Api.Models;
+using Tempo.Api.Tests.Infrastructure;
+using Xunit;
+
+namespace Tempo.Api.Tests.IntegrationTests;
+
+[Collection("Integration Tests")]
+public class WorkoutTimeSeriesEndpointTests : IClassFixture<TempoWebApplicationFactory>
+{
+    private readonly TempoWebApplicationFactory _factory;
+
+    public WorkoutTimeSeriesEndpointTests(TempoWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    private async Task EnsureCleanDatabaseAsync()
+    {
+        using var scope = _factory.Server.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+        await TestDataSeeder.SafeClearAllDataAsync(db, preserveUsers: true);
+    }
+
+    [Fact]
+    public async Task GetWorkoutTimeSeries_Returns404_WhenWorkoutNotFound()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+        var id = Guid.NewGuid();
+
+        var response = await client.GetAsync($"/workouts/{id}/time-series");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        error!.Error.Should().Be("Workout not found");
+    }
+
+    [Fact]
+    public async Task GetWorkoutTimeSeries_ReturnsEmptyItems_WhenNoHeartRateSamples()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Workout workout;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            workout = await TestDataSeeder.SeedWorkoutAsync(db, durationS: 600);
+            await TestDataSeeder.SeedWorkoutWithTimeSeriesAsync(
+                db,
+                workout,
+                intervalSeconds: 60,
+                totalDurationS: 600,
+                includeHeartRate: false,
+                includeCadence: true);
+        }
+
+        var response = await client.GetAsync($"/workouts/{workout.Id}/time-series");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<WorkoutTimeSeriesResponse>();
+        body.Should().NotBeNull();
+        body!.Items.Should().BeEmpty();
+        body.TotalCount.Should().Be(0);
+        body.TotalPages.Should().Be(0);
+        body.Page.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetWorkoutTimeSeries_ReturnsOrderedHeartRateSamples()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Workout workout;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            workout = await TestDataSeeder.SeedWorkoutAsync(db, durationS: 1200);
+            await TestDataSeeder.SeedWorkoutWithTimeSeriesAsync(
+                db,
+                workout,
+                intervalSeconds: 10,
+                totalDurationS: 1200,
+                includeHeartRate: true,
+                includeCadence: false);
+        }
+
+        var response = await client.GetAsync($"/workouts/{workout.Id}/time-series?pageSize=5000");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<WorkoutTimeSeriesResponse>();
+        body.Should().NotBeNull();
+        body!.TotalCount.Should().BeGreaterThan(10);
+        body.Items.Should().NotBeEmpty();
+
+        var elapsed = body.Items.Select(i => i.ElapsedSeconds).ToList();
+        elapsed.Should().BeInAscendingOrder();
+
+        body.Items.Should().OnlyContain(i => i.HeartRateBpm >= 60 && i.HeartRateBpm <= 200);
+    }
+
+    [Fact]
+    public async Task GetWorkoutTimeSeries_PaginatesResults()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Workout workout;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            workout = await TestDataSeeder.SeedWorkoutAsync(db, durationS: 1800);
+            await TestDataSeeder.SeedWorkoutWithTimeSeriesAsync(
+                db,
+                workout,
+                intervalSeconds: 10,
+                totalDurationS: 1800,
+                includeHeartRate: true,
+                includeCadence: false);
+        }
+
+        const int expectedSamples = 181;
+
+        var page1 = await client.GetAsync($"/workouts/{workout.Id}/time-series?page=1&pageSize=50");
+        page1.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body1 = await page1.Content.ReadFromJsonAsync<WorkoutTimeSeriesResponse>();
+        body1!.Items.Should().HaveCount(50);
+        body1.TotalCount.Should().Be(expectedSamples);
+        body1.TotalPages.Should().Be(4);
+
+        var page2 = await client.GetAsync($"/workouts/{workout.Id}/time-series?page=2&pageSize=50");
+        page2.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body2 = await page2.Content.ReadFromJsonAsync<WorkoutTimeSeriesResponse>();
+        body2!.Items.Should().HaveCount(50);
+        body2.Items[0].ElapsedSeconds.Should().BeGreaterThan(body1.Items[^1].ElapsedSeconds);
+
+        var badPage = await client.GetAsync($"/workouts/{workout.Id}/time-series?page=999&pageSize=50");
+        badPage.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetWorkoutTimeSeries_ClampsPageSize_ToMax()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Workout workout;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            workout = await TestDataSeeder.SeedWorkoutAsync(db, durationS: 60);
+            await TestDataSeeder.SeedWorkoutWithTimeSeriesAsync(db, workout, intervalSeconds: 10, totalDurationS: 60);
+        }
+
+        var response = await client.GetAsync($"/workouts/{workout.Id}/time-series?pageSize=999999");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<WorkoutTimeSeriesResponse>();
+        body!.PageSize.Should().Be(5000);
+    }
+
+    [Fact]
+    public async Task GetWorkoutTimeSeries_Returns401_WhenNotAuthenticated()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync($"/workouts/{Guid.NewGuid()}/time-series");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    private sealed class WorkoutTimeSeriesResponse
+    {
+        [JsonPropertyName("items")]
+        public List<WorkoutTimeSeriesItem> Items { get; set; } = [];
+
+        [JsonPropertyName("page")]
+        public int Page { get; set; }
+
+        [JsonPropertyName("pageSize")]
+        public int PageSize { get; set; }
+
+        [JsonPropertyName("totalCount")]
+        public int TotalCount { get; set; }
+
+        [JsonPropertyName("totalPages")]
+        public int TotalPages { get; set; }
+    }
+
+    private sealed class WorkoutTimeSeriesItem
+    {
+        [JsonPropertyName("elapsedSeconds")]
+        public int ElapsedSeconds { get; set; }
+
+        [JsonPropertyName("heartRateBpm")]
+        public int HeartRateBpm { get; set; }
+    }
+
+    private sealed class ErrorResponse
+    {
+        [JsonPropertyName("error")]
+        public string Error { get; set; } = string.Empty;
+    }
+}

--- a/api/Tempo.Api.Tests/IntegrationTests/WorkoutTimeSeriesEndpointTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/WorkoutTimeSeriesEndpointTests.cs
@@ -73,6 +73,33 @@ public class WorkoutTimeSeriesEndpointTests : IClassFixture<TempoWebApplicationF
     }
 
     [Fact]
+    public async Task GetWorkoutTimeSeries_Returns404_WhenNoHeartRateSamplesAndPageOutOfRange()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Workout workout;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            workout = await TestDataSeeder.SeedWorkoutAsync(db, durationS: 600);
+            await TestDataSeeder.SeedWorkoutWithTimeSeriesAsync(
+                db,
+                workout,
+                intervalSeconds: 60,
+                totalDurationS: 600,
+                includeHeartRate: false,
+                includeCadence: true);
+        }
+
+        var response = await client.GetAsync($"/workouts/{workout.Id}/time-series?page=999");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        error!.Error.Should().Be("Page not found");
+    }
+
+    [Fact]
     public async Task GetWorkoutTimeSeries_ReturnsOrderedHeartRateSamples()
     {
         await EnsureCleanDatabaseAsync();

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1338,6 +1338,58 @@
         ]
       }
     },
+    "/workouts/{id}/time-series": {
+      "get": {
+        "tags": [
+          "Workouts"
+        ],
+        "summary": "Paginated heart-rate samples for a workout (from stored time series).",
+        "description": "Returns paginated heart-rate samples from stored workout time series. Each item has elapsedSeconds (integer seconds from workout start) and heartRateBpm (integer). Samples are sparse: only timestamps where heart rate was recorded are included (not a dense sample for every second). GPX imports may be sparse; FIT files are often about one sample per second but not guaranteed. The server does not interpolate missing seconds; clients may interpolate if needed. Ordering is ascending by elapsedSeconds, then by row id when multiple samples share the same second. Default pageSize is 1000 with a maximum of 5000; use multiple requests for long activities.",
+        "operationId": "GetWorkoutTimeSeries",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [ ]
+          }
+        ]
+      }
+    },
     "/workouts/{id}": {
       "get": {
         "tags": [


### PR DESCRIPTION
- Implemented a new endpoint to retrieve paginated heart-rate samples for a specific workout, including validation for workout existence and pagination controls.
- Introduced constants for default and maximum page sizes to manage response size.
- Added comprehensive integration tests to verify endpoint functionality, including scenarios for non-existent workouts, empty results, ordered samples, pagination, and authentication requirements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated API endpoint querying potentially large time-series tables; main risk is pagination/limits and query performance for long workouts, but changes are isolated and covered by integration tests.
> 
> **Overview**
> Adds a new authenticated `GET /workouts/{id}/time-series` endpoint that returns **paginated heart-rate samples** (sparse `elapsedSeconds`/`heartRateBpm` pairs) from stored workout time series, with default/max page-size clamping and out-of-range page handling.
> 
> Updates the OpenAPI spec to document the new route and refreshes docs/instructions (README) so OpenAPI generation uses the **Debug** build output to match CI. Adds integration tests covering not-found workouts/pages, empty results, ordering, pagination behavior, page-size clamping, and auth requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc4239a19de09338d0c38894c8fbb20ea0fd9209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->