### PR TITLE
feat: implement password change functionality with session management

### DIFF
--- a/api/Authentication/TempoJwtBearerEvents.cs
+++ b/api/Authentication/TempoJwtBearerEvents.cs
@@ -1,4 +1,8 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Tempo.Api.Data;
 
 namespace Tempo.Api.Authentication;
 
@@ -15,6 +19,44 @@ public static class TempoJwtBearerEvents
             {
                 context.Token = context.Request.Cookies["authToken"];
                 return Task.CompletedTask;
+            },
+            OnTokenValidated = async context =>
+            {
+                if (context.Principal?.Identity?.IsAuthenticated != true)
+                {
+                    return;
+                }
+
+                var userIdClaim = context.Principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                if (string.IsNullOrEmpty(userIdClaim) || !Guid.TryParse(userIdClaim, out var userId))
+                {
+                    return;
+                }
+
+                var db = context.HttpContext.RequestServices.GetRequiredService<TempoDbContext>();
+                var user = await db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId);
+                if (user == null)
+                {
+                    context.Fail("User not found.");
+                    return;
+                }
+
+                var sessClaim = context.Principal.FindFirst(TempoJwtClaimTypes.SessionVersion)?.Value;
+                if (string.IsNullOrEmpty(sessClaim))
+                {
+                    if (user.SessionVersion != 0)
+                    {
+                        context.Fail("Session no longer valid.");
+                    }
+
+                    return;
+                }
+
+                if (sessClaim != user.SessionVersion.ToString())
+                {
+                    context.Fail("Session no longer valid.");
+                    return;
+                }
             },
             OnChallenge = async context =>
             {

--- a/api/Authentication/TempoJwtClaimTypes.cs
+++ b/api/Authentication/TempoJwtClaimTypes.cs
@@ -1,0 +1,11 @@
+namespace Tempo.Api.Authentication;
+
+/// <summary>
+/// Custom JWT claim types used by Tempo (in addition to standard <see cref="System.Security.Claims.ClaimTypes"/>).
+/// </summary>
+public static class TempoJwtClaimTypes
+{
+    public const string SessionVersion = "sess_ver";
+
+    public const string RememberMe = "remember_me";
+}

--- a/api/Endpoints/AuthEndpoints.cs
+++ b/api/Endpoints/AuthEndpoints.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Tempo.Api.Authentication;
 using Tempo.Api.Authorization;
 using Tempo.Api.Data;
 using Tempo.Api.Models;
@@ -133,31 +134,9 @@ public static class AuthEndpoints
             ? jwtService.RememberMeExpirationDays 
             : jwtService.ExpirationDays;
 
-        // Generate token with appropriate expiration
-        var token = jwtService.GenerateToken(user, expirationDays);
-
+        var token = jwtService.GenerateToken(user, expirationDays, request.RememberMe);
         var expirationDate = DateTime.UtcNow.AddDays(expirationDays);
-
-        // Set httpOnly cookie with production-safe configuration
-        var cookieOptions = new CookieOptions
-        {
-            HttpOnly = true,
-            // In production, always use Secure=true (production should always use HTTPS)
-            // In development, use Request.IsHttps to allow local development without HTTPS
-            Secure = environment.IsProduction() ? true : httpContext.Request.IsHttps,
-            SameSite = SameSiteMode.Lax,
-            Path = "/",
-            Expires = expirationDate
-        };
-
-        // Optionally set cookie domain from configuration for cross-subdomain scenarios
-        var cookieDomain = configuration["Cookie:Domain"];
-        if (!string.IsNullOrWhiteSpace(cookieDomain))
-        {
-            cookieOptions.Domain = cookieDomain;
-        }
-
-        httpContext.Response.Cookies.Append("authToken", token, cookieOptions);
+        AppendAuthTokenCookie(httpContext, environment, configuration, token, expirationDate);
 
         logger.LogInformation("User logged in: {Username}", LogSanitizer.Sanitize(user.Username));
 
@@ -167,6 +146,95 @@ public static class AuthEndpoints
             username = user.Username,
             expiresAt = expirationDate
         });
+    }
+
+    /// <summary>
+    /// Change password (browser session only). Invalidates other JWT sessions; re-issues cookie for this client.
+    /// </summary>
+    private static async Task<IResult> ChangePassword(
+        ChangePasswordRequest request,
+        ClaimsPrincipal claimsPrincipal,
+        HttpContext httpContext,
+        TempoDbContext db,
+        PasswordService passwordService,
+        JwtService jwtService,
+        IWebHostEnvironment environment,
+        IConfiguration configuration,
+        ILogger<Program> logger)
+    {
+        var userId = GetUserIdFromClaims(claimsPrincipal);
+        if (userId == null)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (string.IsNullOrWhiteSpace(request.CurrentPassword))
+        {
+            return Results.BadRequest(new { error = "Current password is required" });
+        }
+
+        if (string.IsNullOrWhiteSpace(request.NewPassword) || request.NewPassword.Length < 6)
+        {
+            return Results.BadRequest(new { error = "Password must be at least 6 characters" });
+        }
+
+        var user = await db.Users.FirstOrDefaultAsync(u => u.Id == userId.Value);
+        if (user == null)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (!passwordService.VerifyPassword(request.CurrentPassword, user.PasswordHash))
+        {
+            return Results.BadRequest(new { error = "Current password is incorrect" });
+        }
+
+        if (request.NewPassword == request.CurrentPassword)
+        {
+            return Results.BadRequest(new { error = "New password must be different from the current password" });
+        }
+
+        user.PasswordHash = passwordService.HashPassword(request.NewPassword);
+        user.SessionVersion++;
+        await db.SaveChangesAsync();
+
+        var rememberMe = string.Equals(
+            claimsPrincipal.FindFirst(TempoJwtClaimTypes.RememberMe)?.Value,
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+        var expirationDays = rememberMe ? jwtService.RememberMeExpirationDays : jwtService.ExpirationDays;
+        var token = jwtService.GenerateToken(user, expirationDays, rememberMe);
+        var expirationDate = DateTime.UtcNow.AddDays(expirationDays);
+        AppendAuthTokenCookie(httpContext, environment, configuration, token, expirationDate);
+
+        logger.LogInformation("Password changed: {Username}", LogSanitizer.Sanitize(user.Username));
+
+        return Results.Ok(new { message = "Password updated successfully" });
+    }
+
+    private static void AppendAuthTokenCookie(
+        HttpContext httpContext,
+        IWebHostEnvironment environment,
+        IConfiguration configuration,
+        string token,
+        DateTime expirationUtc)
+    {
+        var cookieOptions = new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = environment.IsProduction() ? true : httpContext.Request.IsHttps,
+            SameSite = SameSiteMode.Lax,
+            Path = "/",
+            Expires = expirationUtc
+        };
+
+        var cookieDomain = configuration["Cookie:Domain"];
+        if (!string.IsNullOrWhiteSpace(cookieDomain))
+        {
+            cookieOptions.Domain = cookieDomain;
+        }
+
+        httpContext.Response.Cookies.Append("authToken", token, cookieOptions);
     }
 
     /// <summary>
@@ -340,6 +408,16 @@ public static class AuthEndpoints
             .WithSummary("Login")
             .WithDescription("Authenticates user and returns JWT token in httpOnly cookie.");
 
+        group.MapPost("/change-password", ChangePassword)
+            .WithName("ChangePassword")
+            .RequireAuthorization(AuthorizationPolicyNames.JwtSessionOnly)
+            .Produces(200)
+            .Produces(400)
+            .Produces(401)
+            .WithSummary("Change password")
+            .WithDescription(
+                "Updates password and increments session version so other browser sessions are signed out. Re-issues auth cookie for this client.");
+
         group.MapGet("/me", GetCurrentUser)
             .WithName("GetCurrentUser")
             .RequireAuthorization()
@@ -406,6 +484,12 @@ public static class AuthEndpoints
         public string Username { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;
         public bool RememberMe { get; set; } = false;
+    }
+
+    public class ChangePasswordRequest
+    {
+        public string CurrentPassword { get; set; } = string.Empty;
+        public string NewPassword { get; set; } = string.Empty;
     }
 
     public class CreateApiKeyRequest

--- a/api/Migrations/20260510120000_AddUserSessionVersion.Designer.cs
+++ b/api/Migrations/20260510120000_AddUserSessionVersion.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tempo.Api.Data;
@@ -11,9 +12,11 @@ using Tempo.Api.Data;
 namespace Tempo.Api.Migrations
 {
     [DbContext(typeof(TempoDbContext))]
-    partial class TempoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510120000_AddUserSessionVersion")]
+    partial class AddUserSessionVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20260510120000_AddUserSessionVersion.cs
+++ b/api/Migrations/20260510120000_AddUserSessionVersion.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tempo.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserSessionVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SessionVersion",
+                table: "Users",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SessionVersion",
+                table: "Users");
+        }
+    }
+}

--- a/api/Models/User.cs
+++ b/api/Models/User.cs
@@ -18,6 +18,11 @@ public class User
 
     public DateTime? LastLoginAt { get; set; }
 
+    /// <summary>
+    /// Incremented on password change to invalidate outstanding JWTs (see <c>sess_ver</c> claim).
+    /// </summary>
+    public int SessionVersion { get; set; }
+
     public ICollection<ApiKey> ApiKeys { get; set; } = new List<ApiKey>();
 }
 

--- a/api/Services/DatabaseMigrationHelper.cs
+++ b/api/Services/DatabaseMigrationHelper.cs
@@ -44,7 +44,8 @@ public static class DatabaseMigrationHelper
         { ("UserSettings", "UnitPreference"), "20251127020615_AddUnitPreferenceToUserSettings" },
         // AddShoeTracking migration
         { ("Workouts", "ShoeId"), "20251201120000_AddShoeTracking" },
-        { ("UserSettings", "DefaultShoeId"), "20251201120000_AddShoeTracking" }
+        { ("UserSettings", "DefaultShoeId"), "20251201120000_AddShoeTracking" },
+        { ("Users", "SessionVersion"), "20260510120000_AddUserSessionVersion" }
     };
 
     private const string ProductVersion = "9.0.10";

--- a/api/Services/JwtService.cs
+++ b/api/Services/JwtService.cs
@@ -2,6 +2,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
 using Microsoft.IdentityModel.Tokens;
+using Tempo.Api.Authentication;
 using Tempo.Api.Models;
 
 namespace Tempo.Api.Services;
@@ -43,27 +44,29 @@ public class JwtService
     /// Generates a JWT token for a user
     /// </summary>
     /// <param name="user">User entity</param>
-    /// <param name="expirationDays">Optional expiration in days. If not provided, uses default expiration.</param>
+    /// <param name="expirationDays">Optional expiration in days. If not provided, uses default or remember-me based on <paramref name="rememberMe"/>.</param>
+    /// <param name="rememberMe">Stored in the token so session length is preserved after password change.</param>
     /// <returns>JWT token string</returns>
-    public string GenerateToken(User user, int? expirationDays = null)
+    public string GenerateToken(User user, int? expirationDays = null, bool rememberMe = false)
     {
-        var claims = new[]
+        var days = expirationDays ?? (rememberMe ? _rememberMeExpirationDays : _expirationDays);
+        var claims = new Claim[]
         {
             new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
             new Claim(ClaimTypes.Name, user.Username),
-            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new Claim(TempoJwtClaimTypes.SessionVersion, user.SessionVersion.ToString()),
+            new Claim(TempoJwtClaimTypes.RememberMe, rememberMe ? "true" : "false")
         };
 
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_secretKey));
         var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
-        var expiration = expirationDays ?? _expirationDays;
-
         var token = new JwtSecurityToken(
             issuer: _issuer,
             audience: _audience,
             claims: claims,
-            expires: DateTime.UtcNow.AddDays(expiration),
+            expires: DateTime.UtcNow.AddDays(days),
             signingCredentials: credentials
         );
 

--- a/api/Tempo.Api.Tests/IntegrationTests/AuthEndpointsTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/AuthEndpointsTests.cs
@@ -565,6 +565,100 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
 
     #endregion
 
+    #region Change password
+
+    [Fact]
+    public async Task ChangePassword_WhenUnauthenticated_ReturnsUnauthorized()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/auth/change-password", new
+        {
+            currentPassword = "a",
+            newPassword = "bbbbbb"
+        });
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithWrongCurrentPassword_ReturnsBadRequest()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "u1", "Password123!");
+        var response = await client.PostAsJsonAsync("/auth/change-password", new
+        {
+            currentPassword = "wrong",
+            newPassword = "NewPassword123!"
+        });
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var err = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        err.Should().NotBeNull();
+        err!.Error.Should().Contain("Current password");
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithWeakNewPassword_ReturnsBadRequest()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "u1", "Password123!");
+        var response = await client.PostAsJsonAsync("/auth/change-password", new
+        {
+            currentPassword = "Password123!",
+            newPassword = "12345"
+        });
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ChangePassword_SameAsCurrent_ReturnsBadRequest()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "u1", "Password123!");
+        var response = await client.PostAsJsonAsync("/auth/change-password", new
+        {
+            currentPassword = "Password123!",
+            newPassword = "Password123!"
+        });
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithValidCredentials_RevokesOtherJwtSessions_AndClientAKeepsSession()
+    {
+        await EnsureCleanDatabaseAsync();
+        var registerClient = _factory.CreateClient();
+        await registerClient.PostAsJsonAsync("/auth/register", new { username = "soleuser", password = "Password123!" });
+
+        var clientA = _factory.CreateClient();
+        var loginA = await clientA.PostAsJsonAsync("/auth/login", new { username = "soleuser", password = "Password123!" });
+        loginA.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var clientB = _factory.CreateClient();
+        var loginB = await clientB.PostAsJsonAsync("/auth/login", new { username = "soleuser", password = "Password123!" });
+        loginB.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var changeResponse = await clientA.PostAsJsonAsync("/auth/change-password", new
+        {
+            currentPassword = "Password123!",
+            newPassword = "NewPassword456!"
+        });
+        changeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var meB = await clientB.GetAsync("/auth/me");
+        meB.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+
+        var meA = await clientA.GetAsync("/auth/me");
+        meA.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var oldLogin = await _factory.CreateClient().PostAsJsonAsync("/auth/login", new { username = "soleuser", password = "Password123!" });
+        oldLogin.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+
+        var newLogin = await _factory.CreateClient().PostAsJsonAsync("/auth/login", new { username = "soleuser", password = "NewPassword456!" });
+        newLogin.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    #endregion
+
     #region Logout Endpoint Tests
 
     [Fact]

--- a/api/Tempo.Api.Tests/Services/JwtServiceTests.cs
+++ b/api/Tempo.Api.Tests/Services/JwtServiceTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Tempo.Api.Authentication;
 using Tempo.Api.Models;
 using Tempo.Api.Services;
 using Xunit;
@@ -184,6 +185,39 @@ public class JwtServiceTests
         jsonToken.Claims.Should().Contain(c => c.Type == ClaimTypes.NameIdentifier && c.Value == userId.ToString());
         jsonToken.Claims.Should().Contain(c => c.Type == ClaimTypes.Name && c.Value == "testuser");
         jsonToken.Claims.Should().Contain(c => c.Type == JwtRegisteredClaimNames.Jti);
+        jsonToken.Claims.Should().Contain(c => c.Type == TempoJwtClaimTypes.SessionVersion && c.Value == "0");
+        jsonToken.Claims.Should().Contain(c => c.Type == TempoJwtClaimTypes.RememberMe && c.Value == "false");
+    }
+
+    [Fact]
+    public void GenerateToken_EmbedsSessionVersionFromUser()
+    {
+        var service = new JwtService(_configuration, _loggerMock.Object);
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Username = "u",
+            SessionVersion = 3
+        };
+
+        var token = service.GenerateToken(user);
+        var handler = new JwtSecurityTokenHandler();
+        var jsonToken = handler.ReadJwtToken(token);
+
+        jsonToken.Claims.Should().Contain(c => c.Type == TempoJwtClaimTypes.SessionVersion && c.Value == "3");
+    }
+
+    [Fact]
+    public void GenerateToken_WithRememberMe_SetsRememberMeClaimTrue()
+    {
+        var service = new JwtService(_configuration, _loggerMock.Object);
+        var user = new User { Id = Guid.NewGuid(), Username = "u" };
+
+        var token = service.GenerateToken(user, rememberMe: true);
+        var handler = new JwtSecurityTokenHandler();
+        var jsonToken = handler.ReadJwtToken(token);
+
+        jsonToken.Claims.Should().Contain(c => c.Type == TempoJwtClaimTypes.RememberMe && c.Value == "true");
     }
 
     [Fact]

--- a/api/bruno/Tempo.Api/Authentication/Change password.bru
+++ b/api/bruno/Tempo.Api/Authentication/Change password.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Change password
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/auth/change-password
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "currentPassword": "",
+    "newPassword": ""
+  }
+}
+
+docs {
+  Requires a browser JWT session (cookie from login). Re-issues authToken and signs out other sessions.
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -62,6 +62,42 @@
         }
       }
     },
+    "/auth/change-password": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Change password (browser session only). Invalidates other JWT sessions; re-issues cookie for this client.",
+        "description": "Updates password and increments session version so other browser sessions are signed out. Re-issues auth cookie for this client.",
+        "operationId": "ChangePassword",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangePasswordRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [ ]
+          }
+        ]
+      }
+    },
     "/auth/me": {
       "get": {
         "tags": [
@@ -1680,6 +1716,20 @@
   },
   "components": {
     "schemas": {
+      "ChangePasswordRequest": {
+        "type": "object",
+        "properties": {
+          "currentPassword": {
+            "type": "string",
+            "nullable": true
+          },
+          "newPassword": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "CreateApiKeyRequest": {
         "type": "object",
         "properties": {

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -8,6 +8,8 @@ import {
   getQualifyingWorkoutCount,
   getQualifyingWorkoutCountForSplits,
   recalculateAllSplits,
+  getVersion,
+  changePassword,
   type HeartRateZoneSettings,
   type HeartRateCalculationMethod,
   type UpdateHeartRateZoneSettingsRequest
@@ -18,9 +20,8 @@ import { RecalculateSplitsDialog } from '@/components/RecalculateSplitsDialog';
 import UnitPreferenceSection from '@/components/UnitPreferenceSection';
 import { ShoeManagementSection } from '@/components/ShoeManagementSection';
 import { ExportImportSection } from '@/components/ExportImportSection';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { getVersion } from '@/lib/api';
 import { useHeartRateZones, type ZoneRange } from '@/hooks/useHeartRateZones';
 import { invalidateWorkoutQueries } from '@/lib/queryUtils';
 import { AuthGuard } from '@/components/AuthGuard';
@@ -51,6 +52,13 @@ function SettingsPageContent() {
   const [isRecalculatingSplits, setIsRecalculatingSplits] = useState(false);
   const [recalcSplitsError, setRecalcSplitsError] = useState<string | null>(null);
   const [recalcSplitsSuccess, setRecalcSplitsSuccess] = useState(false);
+
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordChangeSaving, setPasswordChangeSaving] = useState(false);
+  const [passwordChangeError, setPasswordChangeError] = useState<string | null>(null);
+  const [passwordChangeSuccess, setPasswordChangeSuccess] = useState(false);
 
   // Fetch version information
   const { data: versionInfo } = useQuery({
@@ -248,6 +256,28 @@ function SettingsPageContent() {
     }
   };
 
+  const handleChangePassword = async (e: FormEvent) => {
+    e.preventDefault();
+    setPasswordChangeError(null);
+    setPasswordChangeSuccess(false);
+    if (newPassword !== confirmPassword) {
+      setPasswordChangeError('New passwords do not match');
+      return;
+    }
+    setPasswordChangeSaving(true);
+    try {
+      await changePassword(currentPassword, newPassword);
+      setPasswordChangeSuccess(true);
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+    } catch (err) {
+      setPasswordChangeError(err instanceof Error ? err.message : 'Failed to change password');
+    } finally {
+      setPasswordChangeSaving(false);
+    }
+  };
+
   return (
     <div className="flex min-h-screen items-start justify-center bg-zinc-50 dark:bg-black">
       <main className="flex min-h-screen w-full max-w-4xl flex-col items-start py-16 px-8">
@@ -261,6 +291,87 @@ function SettingsPageContent() {
         </div>
 
         <div className="w-full space-y-12">
+          {/* Account */}
+          <div className="space-y-6">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 border-b border-gray-200 dark:border-gray-800 pb-2">
+              Account
+            </h2>
+            <div className="bg-white dark:bg-gray-900 p-6 rounded-lg border border-gray-200 dark:border-gray-800">
+              <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                Change password
+              </h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                Updates your password and signs out other browser sessions. This session stays signed in.
+              </p>
+              <form onSubmit={handleChangePassword} className="flex flex-col gap-4 max-w-md">
+                <div>
+                  <label htmlFor="settings-current-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    Current password
+                  </label>
+                  <input
+                    id="settings-current-password"
+                    name="currentPassword"
+                    type="password"
+                    autoComplete="current-password"
+                    value={currentPassword}
+                    onChange={(e) => setCurrentPassword(e.target.value)}
+                    className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100"
+                    required
+                  />
+                </div>
+                <div>
+                  <label htmlFor="settings-new-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    New password
+                  </label>
+                  <input
+                    id="settings-new-password"
+                    name="newPassword"
+                    type="password"
+                    autoComplete="new-password"
+                    value={newPassword}
+                    onChange={(e) => setNewPassword(e.target.value)}
+                    className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100"
+                    required
+                    minLength={6}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="settings-confirm-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    Confirm new password
+                  </label>
+                  <input
+                    id="settings-confirm-password"
+                    name="confirmPassword"
+                    type="password"
+                    autoComplete="new-password"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100"
+                    required
+                    minLength={6}
+                  />
+                </div>
+                <button
+                  type="submit"
+                  disabled={passwordChangeSaving}
+                  className={`w-fit px-6 py-2 rounded-lg font-medium transition-colors ${
+                    passwordChangeSaving
+                      ? 'bg-gray-400 text-white cursor-not-allowed'
+                      : 'bg-gray-900 text-white hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-white'
+                  }`}
+                >
+                  {passwordChangeSaving ? 'Updating…' : 'Update password'}
+                </button>
+                {passwordChangeSuccess && (
+                  <p className="text-sm text-green-600 dark:text-green-400">Password updated successfully.</p>
+                )}
+                {passwordChangeError && (
+                  <p className="text-sm text-red-600 dark:text-red-400">{passwordChangeError}</p>
+                )}
+              </form>
+            </div>
+          </div>
+
           {/* Display Preferences */}
           <div className="space-y-6">
             <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 border-b border-gray-200 dark:border-gray-800 pb-2">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1108,6 +1108,27 @@ export async function logout(): Promise<void> {
   }
 }
 
+export async function changePassword(
+  currentPassword: string,
+  newPassword: string
+): Promise<{ message: string }> {
+  const response = await fetchWithAuth(`${API_BASE_URL}/auth/change-password`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ currentPassword, newPassword }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Password change failed' }));
+    throw new Error(
+      typeof error.error === 'string' ? error.error : `Password change failed: ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
 export async function checkRegistrationAvailable(): Promise<RegistrationAvailableResponse> {
   const response = await fetch(`${API_BASE_URL}/auth/registration-available`, {
     method: 'GET',


### PR DESCRIPTION
- Added a new endpoint for changing user passwords, which invalidates other JWT sessions and re-issues the auth token for the current session.
- Introduced a SessionVersion property in the User model to track password changes and manage session validity.
- Updated JWT generation to include session version and remember me claims.
- Enhanced integration tests to cover password change scenarios and session invalidation.
- Updated frontend to support password change functionality with appropriate UI elements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes JWT issuance/validation and adds server-side session invalidation via a new `Users.SessionVersion` field, impacting authentication behavior for all cookie/Bearer JWT requests. Bugs here could unintentionally log users out or allow stale tokens to remain valid.
> 
> **Overview**
> Adds password self-service via `POST /auth/change-password` (JWT-session-only), which updates the stored password hash, increments a per-user `SessionVersion`, and re-issues the `authToken` cookie for the current browser while implicitly revoking other JWT sessions.
> 
> JWTs now embed custom claims (`sess_ver`, `remember_me`) and the JWT bearer pipeline validates them against the database on each request, failing authentication when the token’s session version no longer matches the user record. This introduces a new `Users.SessionVersion` column/migration, updates migration helpers, expands backend tests and OpenAPI/Bruno docs, and adds a Settings UI + `changePassword()` API call in the frontend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cca7800fba3e0ede18d932812388faa4176dd07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->