### PR TITLE
feat: enhance password change functionality in settings page

### DIFF
--- a/api/Endpoints/AuthEndpoints.cs
+++ b/api/Endpoints/AuthEndpoints.cs
@@ -470,6 +470,10 @@ public static class AuthEndpoints
     public class RegisterRequest
     {
         public string Username { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 16-64 characters; UTF-8 encoding must not exceed 72 bytes. Common passwords, username substring (when username length is at least 3), and 5+ repeated characters in a row are rejected.
+        /// </summary>
         public string Password { get; set; } = string.Empty;
     }
 
@@ -486,6 +490,10 @@ public static class AuthEndpoints
     public class ChangePasswordRequest
     {
         public string CurrentPassword { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 16-64 characters; UTF-8 encoding must not exceed 72 bytes. Same rejection rules as registration (common passwords, username substring when username length is at least 3, 5+ repeated characters in a row).
+        /// </summary>
         public string NewPassword { get; set; } = string.Empty;
     }
 

--- a/api/Endpoints/AuthEndpoints.cs
+++ b/api/Endpoints/AuthEndpoints.cs
@@ -22,8 +22,13 @@ public static class AuthEndpoints
         PasswordService passwordService,
         ILogger<Program> logger)
     {
+        if (string.IsNullOrWhiteSpace(request.Username))
+        {
+            return Results.BadRequest(new { error = "Username must be between 1 and 50 characters" });
+        }
+
         var trimmedUsername = request.Username.Trim();
-        if (string.IsNullOrWhiteSpace(trimmedUsername) || trimmedUsername.Length > 50)
+        if (trimmedUsername.Length > 50)
         {
             return Results.BadRequest(new { error = "Username must be between 1 and 50 characters" });
         }
@@ -170,6 +175,17 @@ public static class AuthEndpoints
             return Results.BadRequest(new { error = "Current password is required" });
         }
 
+        var usernameForPolicy = claimsPrincipal.FindFirst(ClaimTypes.Name)?.Value ?? string.Empty;
+        if (!PasswordPolicy.TryValidate(request.NewPassword, usernameForPolicy, out var newPasswordError))
+        {
+            return Results.BadRequest(new { error = newPasswordError });
+        }
+
+        if (request.NewPassword == request.CurrentPassword)
+        {
+            return Results.BadRequest(new { error = "New password must be different from the current password" });
+        }
+
         var user = await db.Users.FirstOrDefaultAsync(u => u.Id == userId.Value);
         if (user == null)
         {
@@ -179,16 +195,6 @@ public static class AuthEndpoints
         if (!passwordService.VerifyPassword(request.CurrentPassword, user.PasswordHash))
         {
             return Results.BadRequest(new { error = "Current password is incorrect" });
-        }
-
-        if (request.NewPassword == request.CurrentPassword)
-        {
-            return Results.BadRequest(new { error = "New password must be different from the current password" });
-        }
-
-        if (!PasswordPolicy.TryValidate(request.NewPassword, user.Username, out var newPasswordError))
-        {
-            return Results.BadRequest(new { error = newPasswordError });
         }
 
         user.PasswordHash = passwordService.HashPassword(request.NewPassword);

--- a/api/Endpoints/AuthEndpoints.cs
+++ b/api/Endpoints/AuthEndpoints.cs
@@ -22,16 +22,15 @@ public static class AuthEndpoints
         PasswordService passwordService,
         ILogger<Program> logger)
     {
-        // Validate username
-        if (string.IsNullOrWhiteSpace(request.Username) || request.Username.Length > 50)
+        var trimmedUsername = request.Username.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedUsername) || trimmedUsername.Length > 50)
         {
             return Results.BadRequest(new { error = "Username must be between 1 and 50 characters" });
         }
 
-        // Validate password
-        if (string.IsNullOrWhiteSpace(request.Password) || request.Password.Length < 6)
+        if (!PasswordPolicy.TryValidate(request.Password, trimmedUsername, out var passwordError))
         {
-            return Results.BadRequest(new { error = "Password must be at least 6 characters" });
+            return Results.BadRequest(new { error = passwordError });
         }
 
         // Use a serializable transaction to atomically check and create user
@@ -48,8 +47,6 @@ public static class AuthEndpoints
                 return Results.BadRequest(new { error = "Registration is disabled. An account already exists." });
             }
 
-            // Check if username already exists (trim before comparison)
-            var trimmedUsername = request.Username.Trim();
             var existingUser = await db.Users.FirstOrDefaultAsync(u => u.Username == trimmedUsername);
             if (existingUser != null)
             {
@@ -173,11 +170,6 @@ public static class AuthEndpoints
             return Results.BadRequest(new { error = "Current password is required" });
         }
 
-        if (string.IsNullOrWhiteSpace(request.NewPassword) || request.NewPassword.Length < 6)
-        {
-            return Results.BadRequest(new { error = "Password must be at least 6 characters" });
-        }
-
         var user = await db.Users.FirstOrDefaultAsync(u => u.Id == userId.Value);
         if (user == null)
         {
@@ -192,6 +184,11 @@ public static class AuthEndpoints
         if (request.NewPassword == request.CurrentPassword)
         {
             return Results.BadRequest(new { error = "New password must be different from the current password" });
+        }
+
+        if (!PasswordPolicy.TryValidate(request.NewPassword, user.Username, out var newPasswordError))
+        {
+            return Results.BadRequest(new { error = newPasswordError });
         }
 
         user.PasswordHash = passwordService.HashPassword(request.NewPassword);

--- a/api/Endpoints/AuthEndpoints.cs
+++ b/api/Endpoints/AuthEndpoints.cs
@@ -181,11 +181,6 @@ public static class AuthEndpoints
             return Results.BadRequest(new { error = newPasswordError });
         }
 
-        if (request.NewPassword == request.CurrentPassword)
-        {
-            return Results.BadRequest(new { error = "New password must be different from the current password" });
-        }
-
         var user = await db.Users.FirstOrDefaultAsync(u => u.Id == userId.Value);
         if (user == null)
         {
@@ -195,6 +190,11 @@ public static class AuthEndpoints
         if (!passwordService.VerifyPassword(request.CurrentPassword, user.PasswordHash))
         {
             return Results.BadRequest(new { error = "Current password is incorrect" });
+        }
+
+        if (request.NewPassword == request.CurrentPassword)
+        {
+            return Results.BadRequest(new { error = "New password must be different from the current password" });
         }
 
         user.PasswordHash = passwordService.HashPassword(request.NewPassword);

--- a/api/Services/PasswordPolicy.cs
+++ b/api/Services/PasswordPolicy.cs
@@ -1,0 +1,170 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace Tempo.Api.Services;
+
+/// <summary>
+/// NIST/CISA-aligned password rules: length-focused, no mandatory complexity, block common values.
+/// </summary>
+public static class PasswordPolicy
+{
+    public const int MinLength = 16;
+    public const int MaxLength = 64;
+
+    /// <summary>BCrypt uses at most 72 UTF-8 bytes; reject beyond this for predictable behavior.</summary>
+    public const int MaxUtf8Bytes = 72;
+
+    private static readonly HashSet<string> CommonPasswordsLower = BuildBlocklist();
+
+    /// <summary>
+    /// Validates a new password (register or change). Does not trim <paramref name="password"/>; whitespace may be intentional in passphrases.
+    /// </summary>
+    public static bool TryValidate(string password, string username, [NotNullWhen(false)] out string? error)
+    {
+        error = null;
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            error = "Password is required";
+            return false;
+        }
+
+        if (password.Length < MinLength)
+        {
+            error = $"Password must be at least {MinLength} characters";
+            return false;
+        }
+
+        if (password.Length > MaxLength)
+        {
+            error = $"Password must be at most {MaxLength} characters";
+            return false;
+        }
+
+        var utf8Bytes = Encoding.UTF8.GetByteCount(password);
+        if (utf8Bytes > MaxUtf8Bytes)
+        {
+            error = "Password is too long when encoded (maximum 72 bytes in UTF-8); use a shorter passphrase";
+            return false;
+        }
+
+        if (HasFiveOrMoreRepeatedRun(password))
+        {
+            error = "Password must not contain the same character repeated five or more times in a row";
+            return false;
+        }
+
+        var trimmedUsername = username.Trim();
+        if (trimmedUsername.Length >= 3 &&
+            password.Contains(trimmedUsername, StringComparison.OrdinalIgnoreCase))
+        {
+            error = "Password must not contain your username";
+            return false;
+        }
+
+        if (CommonPasswordsLower.Contains(password.ToLowerInvariant()))
+        {
+            error = "This password is too common; choose a different passphrase";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool HasFiveOrMoreRepeatedRun(string password)
+    {
+        if (password.Length < 5)
+        {
+            return false;
+        }
+
+        for (var i = 0; i <= password.Length - 5; i++)
+        {
+            var c = password[i];
+            if (password[i + 1] == c && password[i + 2] == c && password[i + 3] == c && password[i + 4] == c)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static HashSet<string> BuildBlocklist()
+    {
+        string[] items =
+        [
+            "passwordpassword",
+            "passwordpassword1",
+            "1234567890123456",
+            "qwertyuiopasdfgh",
+            "qwertyqwertyqwer",
+            "adminadminadmin1",
+            "welcome welcome!",
+            "iloveyouiloveyou",
+            "sunshinesunshine",
+            "princessprincess",
+            "footballfootball",
+            "baseballbaseball",
+            "abcabcabcabcabcd",
+            "letmeinletmein!!",
+            "monkeymonkey1234",
+            "dragon dragon 12",
+            "master master 123",
+            "login login login!",
+            "passw0rdpassw0rd",
+            "p@ssw0rdp@ssw0rd!",
+            "trustno1trustno1!",
+            "accessaccess12345",
+            "secretsecret1234",
+            "testtesttesttest",
+            "guestguestguest1",
+            "changemechangeme",
+            "defaultdefault12",
+            "temporaltemporal1",
+            "temposelfhosted1",
+            "runnerrunnerrunner",
+            "marathonmarathon1",
+            "strava strava 123",
+            "garmin garmin 123",
+            "applewatchapple1",
+            "correcthorsebatt1",
+            "hunter22hunter2222",
+            "password12345678",
+            "qwerty1234567890",
+            "1q2w3e4r5t6y7u8i",
+            "zaq1xsw2cde3vfr4",
+            "!qaz2wsx3edc4rfv",
+            "asdfasdfasdfasdf",
+            "qwerqwerqwerqwer",
+            "zxcvzxcvzxcvzxcv",
+            "emailaddress1234",
+            "usernameusername",
+            "administrator123",
+            "rootrootrootroot",
+            "supersecretsuper",
+            "mustchangemust123",
+            "winter2024winter2",
+            "summer2024summer",
+            "spring2024spring",
+            "fall2024fall2024",
+            "januaryjanuary01",
+            "decemberdecember",
+            "saturdaysaturday",
+            "sundaysundaysun1",
+            "whateverwhatever1",
+            "nothingnothing12",
+            "blahblahblahblah",
+            "aaaaaaaaaaaaaaaa",
+            "bbbbbbbbbbbbbbbb",
+            "cccccccccccccccc",
+            "dddddddddddddddd",
+            "eeeeeeeeeeeeeeee",
+            "0000000000000000",
+            "1111111111111111",
+            "0123456789012345",
+            "9876543210987654",
+        ];
+
+        return new HashSet<string>(items, StringComparer.Ordinal);
+    }
+}

--- a/api/Services/PasswordPolicy.cs
+++ b/api/Services/PasswordPolicy.cs
@@ -154,13 +154,6 @@ public static class PasswordPolicy
             "whateverwhatever1",
             "nothingnothing12",
             "blahblahblahblah",
-            "aaaaaaaaaaaaaaaa",
-            "bbbbbbbbbbbbbbbb",
-            "cccccccccccccccc",
-            "dddddddddddddddd",
-            "eeeeeeeeeeeeeeee",
-            "0000000000000000",
-            "1111111111111111",
             "0123456789012345",
             "9876543210987654",
         ];

--- a/api/Tempo.Api.Tests/Infrastructure/TestDataSeeder.cs
+++ b/api/Tempo.Api.Tests/Infrastructure/TestDataSeeder.cs
@@ -17,12 +17,12 @@ public static class TestDataSeeder
     /// </summary>
     /// <param name="db">Database context</param>
     /// <param name="username">Username (default: "testuser")</param>
-    /// <param name="password">Plain text password (default: "Test123!")</param>
+    /// <param name="password">Plain text password (default: <see cref="TestPasswords.Default"/>)</param>
     /// <returns>Created User entity</returns>
     public static async Task<User> SeedUserAsync(
         TempoDbContext db,
         string username = "testuser",
-        string password = "Test123!")
+        string password = TestPasswords.Default)
     {
         var passwordService = new PasswordService();
         var user = new User

--- a/api/Tempo.Api.Tests/Infrastructure/TestHttpClientFactory.cs
+++ b/api/Tempo.Api.Tests/Infrastructure/TestHttpClientFactory.cs
@@ -27,12 +27,12 @@ public static class TestHttpClientFactory
     /// </summary>
     /// <param name="factory">WebApplicationFactory instance</param>
     /// <param name="username">Username (default: "testuser")</param>
-    /// <param name="password">Password (default: "Test123!")</param>
+    /// <param name="password">Password (default: <see cref="TestPasswords.Default"/>)</param>
     /// <returns>HttpClient with authentication cookie set</returns>
     public static async Task<HttpClient> CreateAuthenticatedClientAsync(
         WebApplicationFactory<Program> factory,
         string username = "testuser",
-        string password = "Test123!")
+        string password = TestPasswords.Default)
     {
         var client = factory.CreateClient();
 

--- a/api/Tempo.Api.Tests/Infrastructure/TestPasswords.cs
+++ b/api/Tempo.Api.Tests/Infrastructure/TestPasswords.cs
@@ -1,0 +1,10 @@
+namespace Tempo.Api.Tests.Infrastructure;
+
+/// <summary>
+/// Compliant passwords for integration tests (matches <see cref="Tempo.Api.Services.PasswordPolicy"/>).
+/// </summary>
+public static class TestPasswords
+{
+    public const string Default = "Tempo-Integration-Test-Pass!";
+    public const string Alternate = "Tempo-Alternate-Test-Passphrase!";
+}

--- a/api/Tempo.Api.Tests/IntegrationTests/AuthEndpointsTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/AuthEndpointsTests.cs
@@ -672,6 +672,24 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
     }
 
     [Fact]
+    public async Task ChangePassword_WrongCurrentPassword_EqualToNewPassword_ReturnsIncorrectCurrentPasswordNotMustDiffer()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "u1", TestPasswords.Default);
+        var wrongGuessSameAsNew = TestPasswords.Alternate;
+        var response = await client.PostAsJsonAsync("/auth/change-password", new
+        {
+            currentPassword = wrongGuessSameAsNew,
+            newPassword = wrongGuessSameAsNew
+        });
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var err = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        err.Should().NotBeNull();
+        err!.Error.Should().Contain("Current password");
+        err.Error.Should().NotContain("different");
+    }
+
+    [Fact]
     public async Task ChangePassword_WithWeakNewPassword_ReturnsBadRequest()
     {
         await EnsureCleanDatabaseAsync();
@@ -698,6 +716,9 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
             newPassword = TestPasswords.Default
         });
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var err = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        err.Should().NotBeNull();
+        err!.Error.Should().Contain("different");
     }
 
     [Fact]

--- a/api/Tempo.Api.Tests/IntegrationTests/AuthEndpointsTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/AuthEndpointsTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -86,6 +88,31 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
 
         // Act
         var response = await client.PostAsJsonAsync("/auth/register", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var result = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        result.Should().NotBeNull();
+        result!.Error.Should().Contain("Username");
+    }
+
+    [Fact]
+    public async Task Register_WithNullUsernameInJson_ReturnsBadRequest()
+    {
+        // Arrange: System.Text.Json can deserialize JSON null into a non-nullable string when
+        // RespectNullableReferenceTypes is not enabled; endpoint must not call Trim() before a null check.
+        await EnsureCleanDatabaseAsync();
+        var client = _factory.CreateClient();
+
+        var json = JsonSerializer.Serialize(new Dictionary<string, string?>
+        {
+            ["username"] = null,
+            ["password"] = TestPasswords.Default
+        });
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await client.PostAsync("/auth/register", content);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);

--- a/api/Tempo.Api.Tests/IntegrationTests/AuthEndpointsTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/AuthEndpointsTests.cs
@@ -48,7 +48,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var request = new
         {
             username = "newuser",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
 
         // Act
@@ -81,7 +81,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var request = new
         {
             username = "",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
 
         // Act
@@ -104,7 +104,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var request = new
         {
             username = new string('a', 51), // 51 characters
-            password = "Password123!"
+            password = TestPasswords.Default
         };
 
         // Act
@@ -127,7 +127,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var request = new
         {
             username = "newuser",
-            password = "12345" // Less than 6 characters
+            password = "abcdefghijklmno" // 15 characters; policy requires 16+
         };
 
         // Act
@@ -137,7 +137,55 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var result = await response.Content.ReadFromJsonAsync<ErrorResponse>();
         result.Should().NotBeNull();
-        result!.Error.Should().Contain("Password");
+        result!.Error.Should().Contain("16");
+    }
+
+    [Fact]
+    public async Task Register_WithCommonPassword_ReturnsBadRequest()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/auth/register", new
+        {
+            username = "newuser",
+            password = "passwordpassword"
+        });
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var result = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        result.Should().NotBeNull();
+        result!.Error.Should().Contain("common");
+    }
+
+    [Fact]
+    public async Task Register_WithUsernameInPassword_ReturnsBadRequest()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/auth/register", new
+        {
+            username = "myuser",
+            password = "prefix-myuser-extra-stuff"
+        });
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var result = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        result.Should().NotBeNull();
+        result!.Error.Should().Contain("username");
+    }
+
+    [Fact]
+    public async Task Register_WithRepeatedCharacterRun_ReturnsBadRequest()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/auth/register", new
+        {
+            username = "newuser",
+            password = "abcdefghijklllll"
+        });
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var result = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        result.Should().NotBeNull();
+        result!.Error.Should().Contain("repeated");
     }
 
     [Fact]
@@ -173,7 +221,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var request = new
         {
             username = "  newuser  ",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
 
         // Act
@@ -203,7 +251,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var firstRequest = new
         {
             username = "existinguser",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
         await client.PostAsJsonAsync("/auth/register", firstRequest);
 
@@ -211,7 +259,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var secondRequest = new
         {
             username = "existinguser",
-            password = "Password456!"
+            password = TestPasswords.Alternate
         };
 
         // Act
@@ -235,7 +283,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var firstRequest = new
         {
             username = "firstuser",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
         await client.PostAsJsonAsync("/auth/register", firstRequest);
 
@@ -243,7 +291,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var secondRequest = new
         {
             username = "seconduser",
-            password = "Password456!"
+            password = TestPasswords.Alternate
         };
 
         // Act
@@ -271,14 +319,14 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var registerRequest = new
         {
             username = "testuser",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
         await client.PostAsJsonAsync("/auth/register", registerRequest);
 
         var loginRequest = new
         {
             username = "testuser",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
 
         // Act
@@ -308,7 +356,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var registerRequest = new
         {
             username = "testuser",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
         await client.PostAsJsonAsync("/auth/register", registerRequest);
 
@@ -335,7 +383,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var loginRequest = new
         {
             username = "nonexistent",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
 
         // Act
@@ -355,7 +403,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var loginRequest = new
         {
             username = "",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
 
         // Act
@@ -402,7 +450,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var registerRequest = new
         {
             username = "testuser",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
         await client.PostAsJsonAsync("/auth/register", registerRequest);
 
@@ -410,7 +458,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var loginRequest = new
         {
             username = "  testuser  ",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
 
         // Act
@@ -431,7 +479,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var registerRequest = new
         {
             username = "testuser",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
         await client.PostAsJsonAsync("/auth/register", registerRequest);
 
@@ -440,7 +488,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var loginRequest = new
         {
             username = "testuser",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
 
         // Act
@@ -469,8 +517,8 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
     {
         await EnsureCleanDatabaseAsync();
         var client = _factory.CreateClient();
-        await client.PostAsJsonAsync("/auth/register", new { username = "themeCUser", password = "Password123!" });
-        var loginResponse = await client.PostAsJsonAsync("/auth/login", new { username = "themeCUser", password = "Password123!" });
+        await client.PostAsJsonAsync("/auth/register", new { username = "themeCUser", password = TestPasswords.Default });
+        var loginResponse = await client.PostAsJsonAsync("/auth/login", new { username = "themeCUser", password = TestPasswords.Default });
         loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var me = await client.GetAsync("/auth/me");
@@ -486,7 +534,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
     {
         // Arrange
         await EnsureCleanDatabaseAsync();
-        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "testuser", "Test123!");
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "testuser", TestPasswords.Default);
 
         // Act
         var response = await client.GetAsync("/auth/me");
@@ -536,7 +584,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
     {
         // Arrange
         await EnsureCleanDatabaseAsync();
-        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "testuser", "Test123!");
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "testuser", TestPasswords.Default);
         
         // Get user ID from the authenticated response
         var initialResponse = await client.GetAsync("/auth/me");
@@ -584,11 +632,11 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
     public async Task ChangePassword_WithWrongCurrentPassword_ReturnsBadRequest()
     {
         await EnsureCleanDatabaseAsync();
-        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "u1", "Password123!");
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "u1", TestPasswords.Default);
         var response = await client.PostAsJsonAsync("/auth/change-password", new
         {
             currentPassword = "wrong",
-            newPassword = "NewPassword123!"
+            newPassword = TestPasswords.Alternate
         });
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var err = await response.Content.ReadFromJsonAsync<ErrorResponse>();
@@ -600,24 +648,27 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
     public async Task ChangePassword_WithWeakNewPassword_ReturnsBadRequest()
     {
         await EnsureCleanDatabaseAsync();
-        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "u1", "Password123!");
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "u1", TestPasswords.Default);
         var response = await client.PostAsJsonAsync("/auth/change-password", new
         {
-            currentPassword = "Password123!",
-            newPassword = "12345"
+            currentPassword = TestPasswords.Default,
+            newPassword = "abcdefghijklmno"
         });
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var err = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        err.Should().NotBeNull();
+        err!.Error.Should().Contain("16");
     }
 
     [Fact]
     public async Task ChangePassword_SameAsCurrent_ReturnsBadRequest()
     {
         await EnsureCleanDatabaseAsync();
-        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "u1", "Password123!");
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "u1", TestPasswords.Default);
         var response = await client.PostAsJsonAsync("/auth/change-password", new
         {
-            currentPassword = "Password123!",
-            newPassword = "Password123!"
+            currentPassword = TestPasswords.Default,
+            newPassword = TestPasswords.Default
         });
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
@@ -627,20 +678,20 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
     {
         await EnsureCleanDatabaseAsync();
         var registerClient = _factory.CreateClient();
-        await registerClient.PostAsJsonAsync("/auth/register", new { username = "soleuser", password = "Password123!" });
+        await registerClient.PostAsJsonAsync("/auth/register", new { username = "soleuser", password = TestPasswords.Default });
 
         var clientA = _factory.CreateClient();
-        var loginA = await clientA.PostAsJsonAsync("/auth/login", new { username = "soleuser", password = "Password123!" });
+        var loginA = await clientA.PostAsJsonAsync("/auth/login", new { username = "soleuser", password = TestPasswords.Default });
         loginA.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var clientB = _factory.CreateClient();
-        var loginB = await clientB.PostAsJsonAsync("/auth/login", new { username = "soleuser", password = "Password123!" });
+        var loginB = await clientB.PostAsJsonAsync("/auth/login", new { username = "soleuser", password = TestPasswords.Default });
         loginB.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var changeResponse = await clientA.PostAsJsonAsync("/auth/change-password", new
         {
-            currentPassword = "Password123!",
-            newPassword = "NewPassword456!"
+            currentPassword = TestPasswords.Default,
+            newPassword = TestPasswords.Alternate
         });
         changeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
@@ -650,10 +701,10 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var meA = await clientA.GetAsync("/auth/me");
         meA.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var oldLogin = await _factory.CreateClient().PostAsJsonAsync("/auth/login", new { username = "soleuser", password = "Password123!" });
+        var oldLogin = await _factory.CreateClient().PostAsJsonAsync("/auth/login", new { username = "soleuser", password = TestPasswords.Default });
         oldLogin.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
 
-        var newLogin = await _factory.CreateClient().PostAsJsonAsync("/auth/login", new { username = "soleuser", password = "NewPassword456!" });
+        var newLogin = await _factory.CreateClient().PostAsJsonAsync("/auth/login", new { username = "soleuser", password = TestPasswords.Alternate });
         newLogin.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -666,7 +717,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
     {
         // Arrange
         await EnsureCleanDatabaseAsync();
-        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "testuser", "Test123!");
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "testuser", TestPasswords.Default);
 
         // Act
         var response = await client.PostAsync("/auth/logout", null);
@@ -728,7 +779,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         var registerRequest = new
         {
             username = "testuser",
-            password = "Password123!"
+            password = TestPasswords.Default
         };
         await client.PostAsJsonAsync("/auth/register", registerRequest);
 

--- a/api/Tempo.Api.Tests/Services/PasswordPolicyTests.cs
+++ b/api/Tempo.Api.Tests/Services/PasswordPolicyTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using Tempo.Api.Services;
+using Tempo.Api.Tests.Infrastructure;
+using Xunit;
+
+namespace Tempo.Api.Tests.Services;
+
+public class PasswordPolicyTests
+{
+    [Fact]
+    public void TryValidate_ValidPassphrase_ReturnsTrue()
+    {
+        PasswordPolicy.TryValidate("Correct horse battery staple", "alice", out var err).Should().BeTrue();
+        err.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryValidate_ValidMatchesTestDefault_ReturnsTrue()
+    {
+        PasswordPolicy.TryValidate(TestPasswords.Default, "u1", out var err).Should().BeTrue();
+        err.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryValidate_Empty_ReturnsFalse()
+    {
+        PasswordPolicy.TryValidate("", "user", out var err).Should().BeFalse();
+        err.Should().Be("Password is required");
+    }
+
+    [Fact]
+    public void TryValidate_WhitespaceOnly_ReturnsFalse()
+    {
+        PasswordPolicy.TryValidate("   ", "user", out var err).Should().BeFalse();
+        err.Should().Be("Password is required");
+    }
+
+    [Fact]
+    public void TryValidate_TooShort_ReturnsFalse()
+    {
+        PasswordPolicy.TryValidate("abcdefghijklmno", "user", out var err).Should().BeFalse();
+        err.Should().Contain("16");
+    }
+
+    [Fact]
+    public void TryValidate_TooLong_ReturnsFalse()
+    {
+        PasswordPolicy.TryValidate(new string('x', 65), "user", out var err).Should().BeFalse();
+        err.Should().Contain("64");
+    }
+
+    [Fact]
+    public void TryValidate_Utf8TooManyBytes_ReturnsFalse()
+    {
+        var password = new string('\u00e9', 40);
+        password.Length.Should().Be(40);
+        PasswordPolicy.TryValidate(password, "user", out var err).Should().BeFalse();
+        err.Should().Contain("UTF-8");
+    }
+
+    [Fact]
+    public void TryValidate_FiveRepeatedChars_ReturnsFalse()
+    {
+        PasswordPolicy.TryValidate("abcdefghijklllll", "user", out var err).Should().BeFalse();
+        err.Should().Contain("repeated");
+    }
+
+    [Fact]
+    public void TryValidate_UsernameSubstring_ReturnsFalse()
+    {
+        PasswordPolicy.TryValidate("prefix-myuser-extra-stuff", "myuser", out var err).Should().BeFalse();
+        err.Should().Contain("username");
+    }
+
+    [Fact]
+    public void TryValidate_ShortUsername_SkipsSubstringCheck()
+    {
+        PasswordPolicy.TryValidate("ab-prefix-cd-extra!", "xy", out var err).Should().BeTrue();
+        err.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryValidate_Blocklist_ReturnsFalse()
+    {
+        PasswordPolicy.TryValidate("passwordpassword", "user", out var err).Should().BeFalse();
+        err.Should().Contain("common");
+    }
+
+    [Fact]
+    public void TryValidate_FourRepeatedChars_Allowed()
+    {
+        PasswordPolicy.TryValidate("abcdefghijklmnoooo", "user", out var err).Should().BeTrue();
+        err.Should().BeNull();
+    }
+}

--- a/docs/deployment/security.md
+++ b/docs/deployment/security.md
@@ -39,9 +39,14 @@ This guide covers security best practices for deploying Tempo in production.
 
 ### Password Requirements
 
-- Enforce strong passwords (implement in frontend if needed)
-- Use BCrypt for password hashing (already implemented)
-- Consider password complexity requirements
+Tempo enforces NIST/CISA-aligned rules for **new** passwords (registration and password change):
+
+- **Length**: 16–64 characters
+- **Encoding**: UTF-8 length must not exceed 72 bytes (bcrypt limit)
+- **Complexity**: No mandatory mixed case, digits, or symbols—prefer memorable passphrases
+- **Additional checks**: common-password blocklist; password must not contain the username (when the username is at least 3 characters); no single character repeated five or more times in a row
+
+Existing credentials remain valid until the user sets a new password. BCrypt hashing is already implemented.
 
 ### JWT Configuration
 

--- a/docs/developers/api-reference.md
+++ b/docs/developers/api-reference.md
@@ -82,6 +82,8 @@ Content-Type: application/json
 }
 ```
 
+New passwords must be **16–64** characters, with UTF-8 encoding at most **72** bytes. The API rejects common passwords, passwords that contain the username (when the username is at least 3 characters), and passwords with any character repeated five or more times consecutively. There is no mandatory character-class complexity.
+
 ### Login
 
 Authenticate and receive JWT token:

--- a/docs/developers/testing.md
+++ b/docs/developers/testing.md
@@ -198,9 +198,9 @@ public class MyEndpointsTests : IClassFixture<TempoWebApplicationFactory>
    list.Should().HaveCount(3);
    ```
 
-4. **Test Data**: Use `TestDataSeeder` for consistent test data
+4. **Test Data**: Use `TestDataSeeder` for consistent test data. Passwords must satisfy `PasswordPolicy` (16+ characters, etc.); use `TestPasswords.Default` or `TestPasswords.Alternate` from `Tempo.Api.Tests.Infrastructure`.
    ```csharp
-   var user = await TestDataSeeder.SeedUserAsync(_db, "testuser", "password");
+   var user = await TestDataSeeder.SeedUserAsync(_db, "testuser", TestPasswords.Default);
    ```
 
 5. **Database**: Use in-memory SQLite for unit tests
@@ -254,7 +254,7 @@ Helper for creating authenticated HTTP clients:
 var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
 
 // Create authenticated client with custom user
-var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "username", "password");
+var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "username", TestPasswords.Default);
 
 // Create unauthenticated client
 var client = TestHttpClientFactory.CreateUnauthenticatedClient(_factory);
@@ -266,7 +266,7 @@ Helper for seeding test data:
 
 ```csharp
 // Seed user
-var user = await TestDataSeeder.SeedUserAsync(_db, "username", "password");
+var user = await TestDataSeeder.SeedUserAsync(_db, "username", TestPasswords.Default);
 
 // Seed workout
 var workout = await TestDataSeeder.SeedWorkoutAsync(_db, distanceM: 5000);

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -42,7 +42,7 @@ Once all services are running, access Tempo at:
 1. Navigate to `http://localhost:3000`
 2. You'll be redirected to the login page
 3. Register your account (only available when no users exist)
-   - Choose a username and password
+   - Choose a username and a passphrase (**16–64** characters; see [Security](../deployment/security.md#password-requirements) for full rules)
    - Confirm your password
    - After registration, you'll be automatically logged in
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1725,8 +1725,8 @@
           },
           "newPassword": {
             "type": "string",
-            "nullable": true,
-            "description": "16–64 characters; UTF-8 encoding must not exceed 72 bytes. Same rejection rules as registration (common passwords, username substring when username length ≥ 3, 5+ repeated characters in a row)."
+            "description": "16-64 characters; UTF-8 encoding must not exceed 72 bytes. Same rejection rules as registration (common passwords, username substring when username length is at least 3, 5+ repeated characters in a row).",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -1805,8 +1805,8 @@
           },
           "password": {
             "type": "string",
-            "nullable": true,
-            "description": "16–64 characters; UTF-8 encoding must not exceed 72 bytes. Common passwords, username substring (when username length ≥ 3), and 5+ repeated characters in a row are rejected."
+            "description": "16-64 characters; UTF-8 encoding must not exceed 72 bytes. Common passwords, username substring (when username length is at least 3), and 5+ repeated characters in a row are rejected.",
+            "nullable": true
           }
         },
         "additionalProperties": false,

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1725,7 +1725,8 @@
           },
           "newPassword": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "16–64 characters; UTF-8 encoding must not exceed 72 bytes. Same rejection rules as registration (common passwords, username substring when username length ≥ 3, 5+ repeated characters in a row)."
           }
         },
         "additionalProperties": false
@@ -1804,7 +1805,8 @@
           },
           "password": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "16–64 characters; UTF-8 encoding must not exceed 72 bytes. Common passwords, username substring (when username length ≥ 3), and 5+ repeated characters in a row are rejected."
           }
         },
         "additionalProperties": false,

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import * as api from '@/lib/api';
+import { getPasswordLengthAndBytesError } from '@/lib/passwordPolicy';
 
 export default function LoginPage() {
   const [username, setUsername] = useState('');
@@ -44,8 +45,12 @@ export default function LoginPage() {
     e.preventDefault();
     setError(null);
 
-    // Validate password confirmation when registering
     if (isRegistering) {
+      const pwdErr = getPasswordLengthAndBytesError(password);
+      if (pwdErr) {
+        setError(pwdErr);
+        return;
+      }
       if (password !== confirmPassword) {
         setError('Passwords do not match');
         return;
@@ -61,8 +66,8 @@ export default function LoginPage() {
         await login(username, password, rememberMe);
       }
       // Navigation is handled by the auth context
-    } catch (err: any) {
-      setError(err.message || 'An error occurred. Please try again.');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'An error occurred. Please try again.');
     } finally {
       setIsLoading(false);
     }
@@ -81,6 +86,12 @@ export default function LoginPage() {
                 ? 'Create your account to get started'
                 : 'Enter your credentials to access your workouts'}
             </p>
+            {isRegistering && (
+              <p className="text-center text-xs text-gray-500 dark:text-gray-400">
+                Use a memorable passphrase, 16–64 characters. Spaces and Unicode are fine; no required symbol or
+                digit rules.
+              </p>
+            )}
           </div>
           <form className="space-y-6" onSubmit={handleSubmit}>
             {error && (
@@ -119,7 +130,8 @@ export default function LoginPage() {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   disabled={isLoading}
-                  minLength={6}
+                  minLength={isRegistering ? 16 : undefined}
+                  maxLength={isRegistering ? 64 : undefined}
                 />
               </div>
               {isRegistering && (
@@ -137,7 +149,8 @@ export default function LoginPage() {
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                     disabled={isLoading}
-                    minLength={6}
+                    minLength={16}
+                    maxLength={64}
                   />
                 </div>
               )}
@@ -180,7 +193,7 @@ export default function LoginPage() {
                   }}
                   className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-500 dark:hover:text-blue-300"
                 >
-                  Don't have an account? Register
+                  Do not have an account? Register
                 </button>
               </div>
             )}

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -4,7 +4,11 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import * as api from '@/lib/api';
-import { getPasswordLengthAndBytesError } from '@/lib/passwordPolicy';
+import {
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+  getPasswordLengthAndBytesError,
+} from '@/lib/passwordPolicy';
 
 export default function LoginPage() {
   const [username, setUsername] = useState('');
@@ -88,8 +92,8 @@ export default function LoginPage() {
             </p>
             {isRegistering && (
               <p className="text-center text-xs text-gray-500 dark:text-gray-400">
-                Use a memorable passphrase, 16–64 characters. Spaces and Unicode are fine; no required symbol or
-                digit rules.
+                Use a memorable passphrase, {PASSWORD_MIN_LENGTH}–{PASSWORD_MAX_LENGTH} characters. Spaces and
+                Unicode are fine; no required symbol or digit rules.
               </p>
             )}
           </div>
@@ -130,8 +134,8 @@ export default function LoginPage() {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   disabled={isLoading}
-                  minLength={isRegistering ? 16 : undefined}
-                  maxLength={isRegistering ? 64 : undefined}
+                  minLength={isRegistering ? PASSWORD_MIN_LENGTH : undefined}
+                  maxLength={isRegistering ? PASSWORD_MAX_LENGTH : undefined}
                 />
               </div>
               {isRegistering && (
@@ -149,8 +153,8 @@ export default function LoginPage() {
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                     disabled={isLoading}
-                    minLength={16}
-                    maxLength={64}
+                    minLength={PASSWORD_MIN_LENGTH}
+                    maxLength={PASSWORD_MAX_LENGTH}
                   />
                 </div>
               )}

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -260,6 +260,14 @@ function SettingsPageContent() {
     e.preventDefault();
     setPasswordChangeError(null);
     setPasswordChangeSuccess(false);
+    if (!currentPassword.trim()) {
+      setPasswordChangeError('Current password is required');
+      return;
+    }
+    if (!newPassword.trim() || newPassword.length < 6) {
+      setPasswordChangeError('Password must be at least 6 characters');
+      return;
+    }
     if (newPassword !== confirmPassword) {
       setPasswordChangeError('New passwords do not match');
       return;
@@ -291,87 +299,6 @@ function SettingsPageContent() {
         </div>
 
         <div className="w-full space-y-12">
-          {/* Account */}
-          <div className="space-y-6">
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 border-b border-gray-200 dark:border-gray-800 pb-2">
-              Account
-            </h2>
-            <div className="bg-white dark:bg-gray-900 p-6 rounded-lg border border-gray-200 dark:border-gray-800">
-              <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
-                Change password
-              </h3>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-                Updates your password and signs out other browser sessions. This session stays signed in.
-              </p>
-              <form onSubmit={handleChangePassword} className="flex flex-col gap-4 max-w-md">
-                <div>
-                  <label htmlFor="settings-current-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                    Current password
-                  </label>
-                  <input
-                    id="settings-current-password"
-                    name="currentPassword"
-                    type="password"
-                    autoComplete="current-password"
-                    value={currentPassword}
-                    onChange={(e) => setCurrentPassword(e.target.value)}
-                    className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100"
-                    required
-                  />
-                </div>
-                <div>
-                  <label htmlFor="settings-new-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                    New password
-                  </label>
-                  <input
-                    id="settings-new-password"
-                    name="newPassword"
-                    type="password"
-                    autoComplete="new-password"
-                    value={newPassword}
-                    onChange={(e) => setNewPassword(e.target.value)}
-                    className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100"
-                    required
-                    minLength={6}
-                  />
-                </div>
-                <div>
-                  <label htmlFor="settings-confirm-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                    Confirm new password
-                  </label>
-                  <input
-                    id="settings-confirm-password"
-                    name="confirmPassword"
-                    type="password"
-                    autoComplete="new-password"
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                    className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100"
-                    required
-                    minLength={6}
-                  />
-                </div>
-                <button
-                  type="submit"
-                  disabled={passwordChangeSaving}
-                  className={`w-fit px-6 py-2 rounded-lg font-medium transition-colors ${
-                    passwordChangeSaving
-                      ? 'bg-gray-400 text-white cursor-not-allowed'
-                      : 'bg-gray-900 text-white hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-white'
-                  }`}
-                >
-                  {passwordChangeSaving ? 'Updating…' : 'Update password'}
-                </button>
-                {passwordChangeSuccess && (
-                  <p className="text-sm text-green-600 dark:text-green-400">Password updated successfully.</p>
-                )}
-                {passwordChangeError && (
-                  <p className="text-sm text-red-600 dark:text-red-400">{passwordChangeError}</p>
-                )}
-              </form>
-            </div>
-          </div>
-
           {/* Display Preferences */}
           <div className="space-y-6">
             <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 border-b border-gray-200 dark:border-gray-800 pb-2">
@@ -677,6 +604,94 @@ function SettingsPageContent() {
                 </div>
               </div>
             )}
+          </div>
+
+          {/* Account */}
+          <div className="space-y-6">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 border-b border-gray-200 dark:border-gray-800 pb-2">
+              Account
+            </h2>
+            <div className="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
+              <details className="group">
+                <summary className="cursor-pointer list-none flex items-center justify-between gap-4 px-6 py-4 text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800/80 [&::-webkit-details-marker]:hidden">
+                  <span className="text-lg font-semibold">Change password</span>
+                  <span
+                    className="shrink-0 text-gray-500 dark:text-gray-400 transition-transform group-open:rotate-180"
+                    aria-hidden
+                  >
+                    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </span>
+                </summary>
+                <div className="px-6 pb-6 pt-0 border-t border-gray-200 dark:border-gray-800">
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mb-4 mt-4">
+                    Updates your password and signs out other browser sessions. This session stays signed in.
+                  </p>
+                  <form onSubmit={handleChangePassword} className="flex flex-col gap-4 max-w-md">
+                    <div>
+                      <label htmlFor="settings-current-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                        Current password
+                      </label>
+                      <input
+                        id="settings-current-password"
+                        name="currentPassword"
+                        type="password"
+                        autoComplete="current-password"
+                        value={currentPassword}
+                        onChange={(e) => setCurrentPassword(e.target.value)}
+                        className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="settings-new-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                        New password
+                      </label>
+                      <input
+                        id="settings-new-password"
+                        name="newPassword"
+                        type="password"
+                        autoComplete="new-password"
+                        value={newPassword}
+                        onChange={(e) => setNewPassword(e.target.value)}
+                        className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="settings-confirm-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                        Confirm new password
+                      </label>
+                      <input
+                        id="settings-confirm-password"
+                        name="confirmPassword"
+                        type="password"
+                        autoComplete="new-password"
+                        value={confirmPassword}
+                        onChange={(e) => setConfirmPassword(e.target.value)}
+                        className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100"
+                      />
+                    </div>
+                    <button
+                      type="submit"
+                      disabled={passwordChangeSaving}
+                      className={`w-fit px-6 py-2 rounded-lg font-medium transition-colors ${
+                        passwordChangeSaving
+                          ? 'bg-gray-400 text-white cursor-not-allowed'
+                          : 'bg-gray-900 text-white hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-white'
+                      }`}
+                    >
+                      {passwordChangeSaving ? 'Updating…' : 'Update password'}
+                    </button>
+                    {passwordChangeSuccess && (
+                      <p className="text-sm text-green-600 dark:text-green-400">Password updated successfully.</p>
+                    )}
+                    {passwordChangeError && (
+                      <p className="text-sm text-red-600 dark:text-red-400">{passwordChangeError}</p>
+                    )}
+                  </form>
+                </div>
+              </details>
+            </div>
           </div>
 
           {/* System Information */}

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -25,6 +25,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useHeartRateZones, type ZoneRange } from '@/hooks/useHeartRateZones';
 import { invalidateWorkoutQueries } from '@/lib/queryUtils';
 import { AuthGuard } from '@/components/AuthGuard';
+import { getPasswordLengthAndBytesError } from '@/lib/passwordPolicy';
 
 function SettingsPageContent() {
   const queryClient = useQueryClient();
@@ -264,8 +265,9 @@ function SettingsPageContent() {
       setPasswordChangeError('Current password is required');
       return;
     }
-    if (!newPassword.trim() || newPassword.length < 6) {
-      setPasswordChangeError('Password must be at least 6 characters');
+    const newPwdErr = getPasswordLengthAndBytesError(newPassword);
+    if (newPwdErr) {
+      setPasswordChangeError(newPwdErr);
       return;
     }
     if (newPassword !== confirmPassword) {
@@ -627,6 +629,8 @@ function SettingsPageContent() {
                 <div className="px-6 pb-6 pt-0 border-t border-gray-200 dark:border-gray-800">
                   <p className="text-sm text-gray-600 dark:text-gray-400 mb-4 mt-4">
                     Updates your password and signs out other browser sessions. This session stays signed in.
+                    New passwords must be 16–64 characters (UTF-8 under 72 bytes). Use a memorable passphrase—no
+                    required mix of symbols or digits.
                   </p>
                   <form onSubmit={handleChangePassword} className="flex flex-col gap-4 max-w-md">
                     <div>

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -25,7 +25,11 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useHeartRateZones, type ZoneRange } from '@/hooks/useHeartRateZones';
 import { invalidateWorkoutQueries } from '@/lib/queryUtils';
 import { AuthGuard } from '@/components/AuthGuard';
-import { getPasswordLengthAndBytesError } from '@/lib/passwordPolicy';
+import {
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+  getPasswordLengthAndBytesError,
+} from '@/lib/passwordPolicy';
 
 function SettingsPageContent() {
   const queryClient = useQueryClient();
@@ -629,8 +633,8 @@ function SettingsPageContent() {
                 <div className="px-6 pb-6 pt-0 border-t border-gray-200 dark:border-gray-800">
                   <p className="text-sm text-gray-600 dark:text-gray-400 mb-4 mt-4">
                     Updates your password and signs out other browser sessions. This session stays signed in.
-                    New passwords must be 16–64 characters (UTF-8 under 72 bytes). Use a memorable passphrase—no
-                    required mix of symbols or digits.
+                    New passwords must be {PASSWORD_MIN_LENGTH}–{PASSWORD_MAX_LENGTH} characters (UTF-8 under
+                    72 bytes). Use a memorable passphrase—no required mix of symbols or digits.
                   </p>
                   <form onSubmit={handleChangePassword} className="flex flex-col gap-4 max-w-md">
                     <div>

--- a/frontend/lib/passwordPolicy.ts
+++ b/frontend/lib/passwordPolicy.ts
@@ -1,0 +1,32 @@
+/** Mirrors `PasswordPolicy` in the API for pre-submit checks (length + UTF-8 byte cap). */
+
+export const PASSWORD_MIN_LENGTH = 16;
+export const PASSWORD_MAX_LENGTH = 64;
+export const PASSWORD_MAX_UTF8_BYTES = 72;
+
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+/**
+ * Validates length and UTF-8 byte cap. Blocklist, username, and repetition rules are enforced server-side only.
+ */
+export function getPasswordLengthAndBytesError(password: string): string | null {
+  if (!password.trim()) {
+    return 'Password is required';
+  }
+
+  if (password.length < PASSWORD_MIN_LENGTH) {
+    return `Password must be at least ${PASSWORD_MIN_LENGTH} characters`;
+  }
+
+  if (password.length > PASSWORD_MAX_LENGTH) {
+    return `Password must be at most ${PASSWORD_MAX_LENGTH} characters`;
+  }
+
+  if (utf8ByteLength(password) > PASSWORD_MAX_UTF8_BYTES) {
+    return 'Password is too long when encoded (maximum 72 bytes in UTF-8); use a shorter passphrase';
+  }
+
+  return null;
+}


### PR DESCRIPTION
- Added validation for current and new passwords, ensuring the current password is required and the new password meets a minimum length of 6 characters.
- Refactored the password change section to improve UI/UX by utilizing a collapsible details element for better organization.
- Retained existing functionality while enhancing error handling and user feedback during the password change process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes registration and password-change validation rules (now 16–64 chars with additional server-side checks), which can break existing client expectations and test flows but is limited to password-setting paths.
> 
> **Overview**
> Introduces a centralized `PasswordPolicy` and applies it to **registration** and **change password**, tightening new-password rules (16–64 chars, UTF-8 ≤72 bytes, common-password blocklist, username-substring rejection, and 5+ repeated-character runs) and adjusting username trimming/null-handling to avoid `Trim()` on deserialized `null`.
> 
> Updates the frontend registration and settings flows to pre-validate password length/byte limits via `frontend/lib/passwordPolicy.ts`, refreshes the settings change-password UI into a collapsible section, and improves error handling typing.
> 
> Aligns OpenAPI/docs and expands test coverage with new policy-focused unit/integration tests plus shared compliant test passwords (`TestPasswords`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2b5199397ae50ed775108d53c93ef12bb7f2ea1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->