### PR TITLE
feat: add weekly recap endpoint and related metrics

### DIFF
--- a/api/Endpoints/StatsEndpoints.cs
+++ b/api/Endpoints/StatsEndpoints.cs
@@ -9,6 +9,236 @@ namespace Tempo.Api.Endpoints;
 
 public static class StatsEndpoints
 {
+    private const string EasyRunType = "Easy Run";
+
+    /// <summary>
+    /// Aggregates for a single UTC-inclusive workout window [startUtc, endUtc].
+    /// </summary>
+    private sealed record BucketAggregates(
+        int Runs,
+        double DistanceM,
+        long DurationS,
+        double ElevationGainM,
+        int RelativeEffortSum,
+        double? EasyRunAvgHeartRateBpm);
+
+    private sealed record UtcRange(DateTime StartUtc, DateTime EndUtc);
+
+    private sealed record WeeklyRecapUtcContext(
+        DateTime ReferenceLocalDate,
+        DateTime WeekStartLocal,
+        DateTime WeekEndLocal,
+        UtcRange CurrentRange,
+        UtcRange PreviousWeekRange,
+        UtcRange TrailingWeek1,
+        UtcRange TrailingWeek2,
+        UtcRange TrailingWeek3,
+        bool CurrentWeekIsPartial);
+
+    /// <summary>
+    /// Builds Monday–Sunday week boundaries and UTC query ranges. Current range is week-to-date capped at UTC now.
+    /// </summary>
+    private static WeeklyRecapUtcContext BuildWeeklyRecapUtcContext(
+        DateTime utcNow,
+        int? timezoneOffsetMinutes,
+        DateTime? referenceLocalDate)
+    {
+        DateTime localAnchorDate;
+        if (referenceLocalDate.HasValue)
+        {
+            localAnchorDate = referenceLocalDate.Value.Date;
+        }
+        else
+        {
+            var localNow = timezoneOffsetMinutes.HasValue
+                ? utcNow.AddMinutes(timezoneOffsetMinutes.Value)
+                : utcNow;
+            localAnchorDate = localNow.Date;
+        }
+
+        var daysSinceMonday = ((int)localAnchorDate.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        var weekStartLocal = localAnchorDate.AddDays(-daysSinceMonday);
+        var weekEndLocal = weekStartLocal.AddDays(7).AddTicks(-1);
+
+        var weekStartUtc = LocalDateRangeStartToUtc(weekStartLocal, timezoneOffsetMinutes);
+        var weekEndUtc = LocalDateRangeEndToUtc(weekEndLocal, timezoneOffsetMinutes);
+
+        var currentEndUtc = utcNow < weekEndUtc ? utcNow : weekEndUtc;
+        UtcRange currentRange;
+        if (currentEndUtc < weekStartUtc)
+        {
+            currentRange = new UtcRange(weekStartUtc, weekStartUtc.AddTicks(-1));
+        }
+        else
+        {
+            currentRange = new UtcRange(weekStartUtc, currentEndUtc);
+        }
+
+        var previousWeekStartLocal = weekStartLocal.AddDays(-7);
+        var previousWeekEndLocal = previousWeekStartLocal.AddDays(7).AddTicks(-1);
+        var previousWeekRange = new UtcRange(
+            LocalDateRangeStartToUtc(previousWeekStartLocal, timezoneOffsetMinutes),
+            LocalDateRangeEndToUtc(previousWeekEndLocal, timezoneOffsetMinutes));
+
+        UtcRange TrailingWeek(int offsetFromCurrentWeekStart)
+        {
+            var start = weekStartLocal.AddDays(-7 * offsetFromCurrentWeekStart);
+            var end = start.AddDays(7).AddTicks(-1);
+            return new UtcRange(
+                LocalDateRangeStartToUtc(start, timezoneOffsetMinutes),
+                LocalDateRangeEndToUtc(end, timezoneOffsetMinutes));
+        }
+
+        var trailing1 = TrailingWeek(1);
+        var trailing2 = TrailingWeek(2);
+        var trailing3 = TrailingWeek(3);
+
+        var currentWeekIsPartial = utcNow < weekEndUtc && utcNow >= weekStartUtc;
+
+        return new WeeklyRecapUtcContext(
+            localAnchorDate,
+            weekStartLocal,
+            weekEndLocal,
+            currentRange,
+            previousWeekRange,
+            trailing1,
+            trailing2,
+            trailing3,
+            currentWeekIsPartial);
+    }
+
+    private static DateTime LocalDateRangeStartToUtc(DateTime localDateMidnight, int? timezoneOffsetMinutes)
+    {
+        var d = localDateMidnight.Date;
+        return timezoneOffsetMinutes.HasValue
+            ? DateTime.SpecifyKind(d.AddMinutes(-timezoneOffsetMinutes.Value), DateTimeKind.Utc)
+            : DateTime.SpecifyKind(d, DateTimeKind.Utc);
+    }
+
+    private static DateTime LocalDateRangeEndToUtc(DateTime localEndInclusive, int? timezoneOffsetMinutes)
+    {
+        return timezoneOffsetMinutes.HasValue
+            ? DateTime.SpecifyKind(localEndInclusive.AddMinutes(-timezoneOffsetMinutes.Value), DateTimeKind.Utc)
+            : DateTime.SpecifyKind(localEndInclusive, DateTimeKind.Utc);
+    }
+
+    private static async Task<BucketAggregates> GetBucketAggregatesAsync(
+        TempoDbContext db,
+        UtcRange range,
+        CancellationToken cancellationToken = default)
+    {
+        if (range.EndUtc < range.StartUtc)
+        {
+            return new BucketAggregates(0, 0, 0, 0, 0, null);
+        }
+
+        var baseQuery = db.Workouts.AsNoTracking()
+            .Where(w => w.StartedAt >= range.StartUtc && w.StartedAt <= range.EndUtc);
+
+        var runs = await baseQuery.CountAsync(cancellationToken);
+        var distanceM = await baseQuery.SumAsync(w => (double?)w.DistanceM, cancellationToken) ?? 0.0;
+        var durationS = await baseQuery.SumAsync(w => (long?)w.DurationS, cancellationToken) ?? 0L;
+        var elevationGainM = await baseQuery.SumAsync(w => (double?)(w.ElevGainM ?? 0.0), cancellationToken) ?? 0.0;
+        var relativeEffortSum = await baseQuery.SumAsync(w => (int?)w.RelativeEffort, cancellationToken) ?? 0;
+
+        var easyQuery = baseQuery.Where(w =>
+            w.RunType == EasyRunType &&
+            w.AvgHeartRateBpm != null &&
+            w.DurationS > 0);
+
+        var easyDur = await easyQuery.SumAsync(w => (long?)w.DurationS, cancellationToken) ?? 0L;
+        double? easyHrAvg = null;
+        if (easyDur > 0)
+        {
+            var weighted = await easyQuery.SumAsync(
+                w => (double)w.AvgHeartRateBpm!.Value * w.DurationS,
+                cancellationToken);
+            easyHrAvg = Math.Round(weighted / easyDur, 1, MidpointRounding.AwayFromZero);
+        }
+
+        return new BucketAggregates(runs, distanceM, durationS, elevationGainM, relativeEffortSum, easyHrAvg);
+    }
+
+    private static double AverageDouble(double a, double b, double c) => (a + b + c) / 3.0;
+
+    private static double? AverageNullableDouble(double? a, double? b, double? c)
+    {
+        var values = new List<double>(3);
+        if (a.HasValue) values.Add(a.Value);
+        if (b.HasValue) values.Add(b.Value);
+        if (c.HasValue) values.Add(c.Value);
+        if (values.Count == 0)
+        {
+            return null;
+        }
+
+        return Math.Round(values.Average(), 1, MidpointRounding.AwayFromZero);
+    }
+
+    private static object MetricInt(
+        int current,
+        int previous,
+        double trailingAvg,
+        int? deltaVsPrevious)
+    {
+        return new
+        {
+            current,
+            previous,
+            trailingAvg = Math.Round(trailingAvg, 2, MidpointRounding.AwayFromZero),
+            deltaVsPrevious
+        };
+    }
+
+    private static object MetricLong(
+        long current,
+        long previous,
+        double trailingAvg,
+        long? deltaVsPrevious)
+    {
+        return new
+        {
+            current,
+            previous,
+            trailingAvg = Math.Round(trailingAvg, 2, MidpointRounding.AwayFromZero),
+            deltaVsPrevious
+        };
+    }
+
+    private static object MetricDouble(
+        double current,
+        double previous,
+        double trailingAvg,
+        double? deltaVsPrevious)
+    {
+        return new
+        {
+            current,
+            previous,
+            trailingAvg = Math.Round(trailingAvg, 2, MidpointRounding.AwayFromZero),
+            deltaVsPrevious
+        };
+    }
+
+    private static object MetricNullableDouble(
+        double? current,
+        double? previous,
+        double? trailingAvg,
+        double? deltaVsPrevious)
+    {
+        return new
+        {
+            current,
+            previous,
+            trailingAvg = trailingAvg.HasValue
+                ? Math.Round(trailingAvg.Value, 1, MidpointRounding.AwayFromZero)
+                : (double?)null,
+            deltaVsPrevious = deltaVsPrevious.HasValue
+                ? Math.Round(deltaVsPrevious.Value, 1, MidpointRounding.AwayFromZero)
+                : (double?)null
+        };
+    }
+
     /// <summary>
     /// Calculate daily totals (in miles) from a list of workouts, grouped by day of week (Monday=0, Sunday=6).
     /// </summary>
@@ -239,6 +469,82 @@ public static class StatsEndpoints
             rangeMin = rangeMin,
             rangeMax = rangeMax,
             currentWeekTotal = currentWeekTotal
+        });
+    }
+
+    /// <summary>
+    /// Get weekly recap aggregates for dashboards and CLI integrations.
+    /// </summary>
+    /// <param name="db">Database context</param>
+    /// <param name="logger">Logger instance</param>
+    /// <param name="timezoneOffsetMinutes">Timezone offset in minutes (negative for timezones behind UTC), same as other stats endpoints.</param>
+    /// <param name="referenceDate">Optional local calendar date (yyyy-MM-dd) that selects which Monday–Sunday week is treated as &quot;current&quot;; defaults to today in the offset frame.</param>
+    /// <returns>Counts, distance, duration, elevation, relative effort, and easy-run HR with current (week-to-date), previous week, trailing 3-week average, and week-over-week deltas.</returns>
+    /// <remarks>
+    /// Week boundaries are Monday 00:00 through Sunday 23:59:59.999 in the local frame implied by <paramref name="timezoneOffsetMinutes"/>.
+    /// The current window is [weekStartUtc, min(UTC now, weekEndUtc)] so mid-week responses reflect week-to-date; the response field <c>currentWeekIsPartial</c> is true when UTC now falls inside the current week window.
+    /// Trailing averages use the three full calendar weeks immediately before the current week (offsets -1, -2, -3), matching <c>/stats/relative-effort</c>.
+    /// Elevation uses SUM(COALESCE(ElevGainM, 0)). Relative effort sums only non-null values. Easy-run HR uses RunType &quot;Easy Run&quot; with duration-weighted average HR; weeks with no qualifying runs return null for that metric.
+    /// Deleted workouts do not appear. Fixed-offset timezones do not model DST; clients should send the offset in effect for the user at request time.
+    /// </remarks>
+    private static async Task<IResult> GetWeeklyRecap(
+        TempoDbContext db,
+        ILogger<Program> logger,
+        [FromQuery] int? timezoneOffsetMinutes = null,
+        [FromQuery] string? referenceDate = null)
+    {
+        DateTime? referenceLocalDate = null;
+        if (!string.IsNullOrWhiteSpace(referenceDate))
+        {
+            if (!DateTime.TryParse(referenceDate, null, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed))
+            {
+                return Results.BadRequest(new { error = "Invalid referenceDate; use yyyy-MM-dd." });
+            }
+
+            referenceLocalDate = parsed.Date;
+        }
+
+        var utcNow = DateTime.UtcNow;
+        var ctx = BuildWeeklyRecapUtcContext(utcNow, timezoneOffsetMinutes, referenceLocalDate);
+
+        var current = await GetBucketAggregatesAsync(db, ctx.CurrentRange);
+        var previous = await GetBucketAggregatesAsync(db, ctx.PreviousWeekRange);
+        var t1 = await GetBucketAggregatesAsync(db, ctx.TrailingWeek1);
+        var t2 = await GetBucketAggregatesAsync(db, ctx.TrailingWeek2);
+        var t3 = await GetBucketAggregatesAsync(db, ctx.TrailingWeek3);
+
+        var trRuns = AverageDouble(t1.Runs, t2.Runs, t3.Runs);
+        var trDist = AverageDouble(t1.DistanceM, t2.DistanceM, t3.DistanceM);
+        var trDur = AverageDouble(t1.DurationS, t2.DurationS, t3.DurationS);
+        var trElev = AverageDouble(t1.ElevationGainM, t2.ElevationGainM, t3.ElevationGainM);
+        var trEffort = AverageDouble(t1.RelativeEffortSum, t2.RelativeEffortSum, t3.RelativeEffortSum);
+        var trEasyHr = AverageNullableDouble(t1.EasyRunAvgHeartRateBpm, t2.EasyRunAvgHeartRateBpm, t3.EasyRunAvgHeartRateBpm);
+
+        double? easyDelta = current.EasyRunAvgHeartRateBpm.HasValue && previous.EasyRunAvgHeartRateBpm.HasValue
+            ? current.EasyRunAvgHeartRateBpm.Value - previous.EasyRunAvgHeartRateBpm.Value
+            : null;
+
+        return Results.Ok(new
+        {
+            weekStart = ctx.WeekStartLocal.ToString("yyyy-MM-dd"),
+            weekEnd = ctx.WeekEndLocal.Date.ToString("yyyy-MM-dd"),
+            referenceDate = ctx.ReferenceLocalDate.ToString("yyyy-MM-dd"),
+            timezoneOffsetMinutes,
+            currentWeekIsPartial = ctx.CurrentWeekIsPartial,
+            generatedAtUtc = utcNow.ToString("O"),
+            metrics = new
+            {
+                runs = MetricInt(current.Runs, previous.Runs, trRuns, current.Runs - previous.Runs),
+                distanceM = MetricDouble(current.DistanceM, previous.DistanceM, trDist, current.DistanceM - previous.DistanceM),
+                durationS = MetricLong(current.DurationS, previous.DurationS, trDur, current.DurationS - previous.DurationS),
+                elevationGainM = MetricDouble(current.ElevationGainM, previous.ElevationGainM, trElev, current.ElevationGainM - previous.ElevationGainM),
+                relativeEffortSum = MetricInt(current.RelativeEffortSum, previous.RelativeEffortSum, trEffort, current.RelativeEffortSum - previous.RelativeEffortSum),
+                easyRunAvgHeartRateBpm = MetricNullableDouble(
+                    current.EasyRunAvgHeartRateBpm,
+                    previous.EasyRunAvgHeartRateBpm,
+                    trEasyHr,
+                    easyDelta)
+            }
         });
     }
 
@@ -692,6 +998,16 @@ public static class StatsEndpoints
             .Produces(200)
             .WithSummary("Get relative effort stats")
             .WithDescription("Returns cumulative relative effort for the current week and 3-week average range");
+
+        group.MapGet("/weekly-recap", GetWeeklyRecap)
+            .WithName("GetWeeklyRecap")
+            .Produces(200)
+            .Produces(400)
+            .WithSummary("Get weekly recap aggregates")
+            .WithDescription(
+                "Returns run count, distance, duration, elevation gain, relative effort sum, and easy-run average HR for the current (week-to-date) window, previous full week, and trailing 3-week averages, with week-over-week deltas. " +
+                "Optional referenceDate (yyyy-MM-dd) selects the calendar week in the timezoneOffsetMinutes frame. " +
+                "Easy runs are RunType \"Easy Run\" with duration-weighted average heart rate.");
 
         group.MapGet("/best-efforts", GetBestEfforts)
             .WithName("GetBestEfforts")

--- a/api/Endpoints/StatsEndpoints.cs
+++ b/api/Endpoints/StatsEndpoints.cs
@@ -30,7 +30,6 @@ public static class StatsEndpoints
         DateTime WeekEndLocal,
         UtcRange CurrentRange,
         UtcRange PreviousWeekRange,
-        UtcRange TrailingWeek1,
         UtcRange TrailingWeek2,
         UtcRange TrailingWeek3,
         bool CurrentWeekIsPartial);
@@ -89,7 +88,6 @@ public static class StatsEndpoints
                 LocalDateRangeEndToUtc(end, timezoneOffsetMinutes));
         }
 
-        var trailing1 = TrailingWeek(1);
         var trailing2 = TrailingWeek(2);
         var trailing3 = TrailingWeek(3);
 
@@ -101,7 +99,6 @@ public static class StatsEndpoints
             weekEndLocal,
             currentRange,
             previousWeekRange,
-            trailing1,
             trailing2,
             trailing3,
             currentWeekIsPartial);
@@ -509,16 +506,15 @@ public static class StatsEndpoints
 
         var current = await GetBucketAggregatesAsync(db, ctx.CurrentRange);
         var previous = await GetBucketAggregatesAsync(db, ctx.PreviousWeekRange);
-        var t1 = await GetBucketAggregatesAsync(db, ctx.TrailingWeek1);
         var t2 = await GetBucketAggregatesAsync(db, ctx.TrailingWeek2);
         var t3 = await GetBucketAggregatesAsync(db, ctx.TrailingWeek3);
 
-        var trRuns = AverageDouble(t1.Runs, t2.Runs, t3.Runs);
-        var trDist = AverageDouble(t1.DistanceM, t2.DistanceM, t3.DistanceM);
-        var trDur = AverageDouble(t1.DurationS, t2.DurationS, t3.DurationS);
-        var trElev = AverageDouble(t1.ElevationGainM, t2.ElevationGainM, t3.ElevationGainM);
-        var trEffort = AverageDouble(t1.RelativeEffortSum, t2.RelativeEffortSum, t3.RelativeEffortSum);
-        var trEasyHr = AverageNullableDouble(t1.EasyRunAvgHeartRateBpm, t2.EasyRunAvgHeartRateBpm, t3.EasyRunAvgHeartRateBpm);
+        var trRuns = AverageDouble(previous.Runs, t2.Runs, t3.Runs);
+        var trDist = AverageDouble(previous.DistanceM, t2.DistanceM, t3.DistanceM);
+        var trDur = AverageDouble(previous.DurationS, t2.DurationS, t3.DurationS);
+        var trElev = AverageDouble(previous.ElevationGainM, t2.ElevationGainM, t3.ElevationGainM);
+        var trEffort = AverageDouble(previous.RelativeEffortSum, t2.RelativeEffortSum, t3.RelativeEffortSum);
+        var trEasyHr = AverageNullableDouble(previous.EasyRunAvgHeartRateBpm, t2.EasyRunAvgHeartRateBpm, t3.EasyRunAvgHeartRateBpm);
 
         double? easyDelta = current.EasyRunAvgHeartRateBpm.HasValue && previous.EasyRunAvgHeartRateBpm.HasValue
             ? current.EasyRunAvgHeartRateBpm.Value - previous.EasyRunAvgHeartRateBpm.Value

--- a/api/Tempo.Api.Tests/IntegrationTests/StatsEndpointsTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/StatsEndpointsTests.cs
@@ -344,6 +344,154 @@ public class StatsEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         return workouts;
     }
 
+    /// <summary>
+    /// Seeds deterministic workouts for /stats/weekly-recap using a pinned reference week in the past (UTC local).
+    /// referenceDate 2020-06-10 -> current week 2020-06-08 .. 2020-06-14; previous week 2020-06-01 .. 2020-06-07.
+    /// </summary>
+    private async Task SeedWeeklyRecapFixtureAsync(TempoDbContext db)
+    {
+        var w1 = await TestDataSeeder.SeedWorkoutAsync(
+            db,
+            startedAt: new DateTime(2020, 6, 8, 12, 0, 0, DateTimeKind.Utc),
+            distanceM: 1000,
+            durationS: 600,
+            name: "Recap current Mon");
+        w1.ElevGainM = 10;
+        w1.RelativeEffort = 20;
+        w1.RunType = "Easy Run";
+        w1.AvgHeartRateBpm = 140;
+
+        var w2 = await TestDataSeeder.SeedWorkoutAsync(
+            db,
+            startedAt: new DateTime(2020, 6, 9, 12, 0, 0, DateTimeKind.Utc),
+            distanceM: 2000,
+            durationS: 900,
+            name: "Recap current Tue");
+        w2.ElevGainM = null;
+        w2.RelativeEffort = null;
+        w2.RunType = "Race";
+        w2.AvgHeartRateBpm = 180;
+
+        var wPrev = await TestDataSeeder.SeedWorkoutAsync(
+            db,
+            startedAt: new DateTime(2020, 6, 5, 12, 0, 0, DateTimeKind.Utc),
+            distanceM: 5000,
+            durationS: 1800,
+            name: "Recap previous Fri");
+        wPrev.ElevGainM = 50;
+        wPrev.RelativeEffort = 30;
+        wPrev.RunType = "Easy Run";
+        wPrev.AvgHeartRateBpm = 130;
+
+        await db.SaveChangesAsync();
+    }
+
+    #endregion
+
+    #region Weekly Recap Tests
+
+    [Fact]
+    public async Task GetWeeklyRecap_ReturnsZeros_WhenNoWorkouts()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        var response = await client.GetAsync("/stats/weekly-recap?referenceDate=2020-06-10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<WeeklyRecapResponse>();
+        result.Should().NotBeNull();
+        result!.Metrics.Runs.Current.Should().Be(0);
+        result.Metrics.Runs.Previous.Should().Be(0);
+        result.Metrics.Runs.TrailingAvg.Should().Be(0);
+        result.Metrics.Runs.DeltaVsPrevious.Should().Be(0);
+        result.Metrics.RelativeEffortSum.Current.Should().Be(0);
+        result.Metrics.EasyRunAvgHeartRateBpm.Current.Should().BeNull();
+        result.ReferenceDate.Should().Be("2020-06-10");
+    }
+
+    [Fact]
+    public async Task GetWeeklyRecap_Returns400_WhenReferenceDateInvalid()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        var response = await client.GetAsync("/stats/weekly-recap?referenceDate=not-a-date");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GetWeeklyRecap_AggregatesPinnedWeek_WithElevationCoalesceAndEffortNulls()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            await SeedWeeklyRecapFixtureAsync(db);
+        }
+
+        var response = await client.GetAsync("/stats/weekly-recap?referenceDate=2020-06-10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<WeeklyRecapResponse>();
+        result.Should().NotBeNull();
+
+        result!.WeekStart.Should().Be("2020-06-08");
+        result.WeekEnd.Should().Be("2020-06-14");
+        result.CurrentWeekIsPartial.Should().BeFalse();
+
+        result.Metrics.Runs.Current.Should().Be(2);
+        result.Metrics.Runs.Previous.Should().Be(1);
+        result.Metrics.Runs.TrailingAvg.Should().BeApproximately(0.33, 0.01);
+        result.Metrics.Runs.DeltaVsPrevious.Should().Be(1);
+
+        result.Metrics.DistanceM.Current.Should().Be(3000);
+        result.Metrics.DistanceM.Previous.Should().Be(5000);
+
+        result.Metrics.DurationS.Current.Should().Be(1500);
+        result.Metrics.DurationS.Previous.Should().Be(1800);
+
+        result.Metrics.ElevationGainM.Current.Should().Be(10);
+        result.Metrics.ElevationGainM.Previous.Should().Be(50);
+
+        result.Metrics.RelativeEffortSum.Current.Should().Be(20);
+        result.Metrics.RelativeEffortSum.Previous.Should().Be(30);
+
+        result.Metrics.EasyRunAvgHeartRateBpm.Current.Should().Be(140);
+        result.Metrics.EasyRunAvgHeartRateBpm.Previous.Should().Be(130);
+        result.Metrics.EasyRunAvgHeartRateBpm.DeltaVsPrevious.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task GetWeeklyRecap_IgnoresNonEasyRunsForHeartRateAverage()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            var w = await TestDataSeeder.SeedWorkoutAsync(
+                db,
+                startedAt: new DateTime(2020, 6, 10, 12, 0, 0, DateTimeKind.Utc),
+                distanceM: 8000,
+                durationS: 2400,
+                name: "Hard only");
+            w.RunType = "Workout";
+            w.AvgHeartRateBpm = 175;
+            await db.SaveChangesAsync();
+        }
+
+        var response = await client.GetAsync("/stats/weekly-recap?referenceDate=2020-06-10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<WeeklyRecapResponse>();
+        result!.Metrics.EasyRunAvgHeartRateBpm.Current.Should().BeNull();
+    }
+
     #endregion
 
     #region Weekly Stats Tests
@@ -1667,6 +1815,13 @@ public class StatsEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         effortResult!.CurrentWeek.Should().AllBeEquivalentTo(0);
         effortResult.CurrentWeekTotal.Should().Be(0);
 
+        // Act & Assert - Weekly Recap
+        var recapResponse = await client.GetAsync("/stats/weekly-recap");
+        recapResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var recapResult = await recapResponse.Content.ReadFromJsonAsync<WeeklyRecapResponse>();
+        recapResult!.Metrics.Runs.Current.Should().Be(0);
+        recapResult.Metrics.Runs.Previous.Should().Be(0);
+
         // Act & Assert - Yearly Stats
         var yearlyResponse = await client.GetAsync("/stats/yearly");
         yearlyResponse.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -1748,6 +1903,9 @@ public class StatsEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         effortResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var effortResult = await effortResponse.Content.ReadFromJsonAsync<RelativeEffortStatsResponse>();
         effortResult!.CurrentWeekTotal.Should().Be(0); // No relative effort
+
+        var recapResponse = await client.GetAsync("/stats/weekly-recap");
+        recapResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]
@@ -1773,11 +1931,69 @@ public class StatsEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         weeklyResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var weeklyResult = await weeklyResponse.Content.ReadFromJsonAsync<WeeklyStatsResponse>();
         weeklyResult!.DailyMiles.Sum().Should().BeGreaterThan(0);
+
+        var recapResponse = await client.GetAsync("/stats/weekly-recap");
+        recapResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var recapResult = await recapResponse.Content.ReadFromJsonAsync<WeeklyRecapResponse>();
+        recapResult!.Metrics.Runs.Current.Should().BeGreaterThan(0);
     }
 
     #endregion
 
     #region Response Models
+
+    private class WeeklyRecapResponse
+    {
+        public string WeekStart { get; set; } = string.Empty;
+        public string WeekEnd { get; set; } = string.Empty;
+        public string ReferenceDate { get; set; } = string.Empty;
+        public int? TimezoneOffsetMinutes { get; set; }
+        public bool CurrentWeekIsPartial { get; set; }
+        public string GeneratedAtUtc { get; set; } = string.Empty;
+        public WeeklyRecapMetricsBlock Metrics { get; set; } = null!;
+    }
+
+    private class WeeklyRecapMetricsBlock
+    {
+        public WeeklyRecapMetricInt Runs { get; set; } = null!;
+        public WeeklyRecapMetricDouble DistanceM { get; set; } = null!;
+        public WeeklyRecapMetricLong DurationS { get; set; } = null!;
+        public WeeklyRecapMetricDouble ElevationGainM { get; set; } = null!;
+        public WeeklyRecapMetricInt RelativeEffortSum { get; set; } = null!;
+        public WeeklyRecapMetricNullableDouble EasyRunAvgHeartRateBpm { get; set; } = null!;
+    }
+
+    private class WeeklyRecapMetricInt
+    {
+        public int Current { get; set; }
+        public int Previous { get; set; }
+        public double TrailingAvg { get; set; }
+        public int DeltaVsPrevious { get; set; }
+    }
+
+    private class WeeklyRecapMetricLong
+    {
+        public long Current { get; set; }
+        public long Previous { get; set; }
+        public double TrailingAvg { get; set; }
+        public long DeltaVsPrevious { get; set; }
+    }
+
+    private class WeeklyRecapMetricDouble
+    {
+        public double Current { get; set; }
+        public double Previous { get; set; }
+        public double TrailingAvg { get; set; }
+        public double DeltaVsPrevious { get; set; }
+    }
+
+    private class WeeklyRecapMetricNullableDouble
+    {
+        public double? Current { get; set; }
+        public double? Previous { get; set; }
+        public double? TrailingAvg { get; set; }
+        public double? DeltaVsPrevious { get; set; }
+    }
 
     private class WeeklyStatsResponse
     {

--- a/api/bruno/Tempo.Api/Workouts/Get weekly recap aggregates.bru
+++ b/api/bruno/Tempo.Api/Workouts/Get weekly recap aggregates.bru
@@ -1,0 +1,45 @@
+meta {
+  name: Get weekly recap aggregates
+  type: http
+  seq: 15
+}
+
+get {
+  url: {{baseUrl}}/stats/weekly-recap
+  body: none
+  auth: inherit
+}
+
+params:query {
+  ~timezoneOffsetMinutes: 
+  ~referenceDate: 
+}
+
+example {
+  name: 200 Response
+  description: OK
+  
+  request: {
+    url: {{baseUrl}}/stats/weekly-recap
+    method: GET
+    mode: none
+    params:query: {
+      ~timezoneOffsetMinutes: 
+      ~referenceDate: 
+    }
+  }
+  
+  response: {
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -691,6 +691,48 @@
         ]
       }
     },
+    "/stats/weekly-recap": {
+      "get": {
+        "tags": [
+          "Stats"
+        ],
+        "summary": "Get weekly recap aggregates for dashboards and CLI integrations.",
+        "description": "Week boundaries are Monday 00:00 through Sunday 23:59:59.999 in the local frame implied by timezoneOffsetMinutes.\nThe current window is [weekStartUtc, min(UTC now, weekEndUtc)] so mid-week responses reflect week-to-date; the response field `currentWeekIsPartial` is true when UTC now falls inside the current week window.\nTrailing averages use the three full calendar weeks immediately before the current week (offsets -1, -2, -3), matching `/stats/relative-effort`.\nElevation uses SUM(COALESCE(ElevGainM, 0)). Relative effort sums only non-null values. Easy-run HR uses RunType \"Easy Run\" with duration-weighted average HR; weeks with no qualifying runs return null for that metric.\nDeleted workouts do not appear. Fixed-offset timezones do not model DST; clients should send the offset in effect for the user at request time.",
+        "operationId": "GetWeeklyRecap",
+        "parameters": [
+          {
+            "name": "timezoneOffsetMinutes",
+            "in": "query",
+            "description": "Timezone offset in minutes (negative for timezones behind UTC), same as other stats endpoints.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "referenceDate",
+            "in": "query",
+            "description": "Optional local calendar date (yyyy-MM-dd) that selects which Monday–Sunday week is treated as \"current\"; defaults to today in the offset frame.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [ ]
+          }
+        ]
+      }
+    },
     "/stats/best-efforts": {
       "get": {
         "tags": [

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -525,6 +525,51 @@ export interface RelativeEffortStatsResponse {
   currentWeekTotal: number;
 }
 
+export interface WeeklyRecapMetricInt {
+  current: number;
+  previous: number;
+  trailingAvg: number;
+  deltaVsPrevious: number;
+}
+
+export interface WeeklyRecapMetricLong {
+  current: number;
+  previous: number;
+  trailingAvg: number;
+  deltaVsPrevious: number;
+}
+
+export interface WeeklyRecapMetricDouble {
+  current: number;
+  previous: number;
+  trailingAvg: number;
+  deltaVsPrevious: number;
+}
+
+export interface WeeklyRecapMetricNullableDouble {
+  current: number | null;
+  previous: number | null;
+  trailingAvg: number | null;
+  deltaVsPrevious: number | null;
+}
+
+export interface WeeklyRecapResponse {
+  weekStart: string;
+  weekEnd: string;
+  referenceDate: string;
+  timezoneOffsetMinutes: number | null;
+  currentWeekIsPartial: boolean;
+  generatedAtUtc: string;
+  metrics: {
+    runs: WeeklyRecapMetricInt;
+    distanceM: WeeklyRecapMetricDouble;
+    durationS: WeeklyRecapMetricLong;
+    elevationGainM: WeeklyRecapMetricDouble;
+    relativeEffortSum: WeeklyRecapMetricInt;
+    easyRunAvgHeartRateBpm: WeeklyRecapMetricNullableDouble;
+  };
+}
+
 export interface YearlyStatsResponse {
   currentYear: number;
   previousYear: number;
@@ -571,6 +616,34 @@ export async function getRelativeEffortStats(timezoneOffsetMinutes?: number): Pr
 
   if (!response.ok) {
     throw new Error(`Failed to fetch relative effort stats: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+export async function getWeeklyRecap(
+  timezoneOffsetMinutes?: number,
+  referenceDate?: string
+): Promise<WeeklyRecapResponse> {
+  const searchParams = new URLSearchParams();
+  if (timezoneOffsetMinutes !== undefined) {
+    searchParams.set('timezoneOffsetMinutes', timezoneOffsetMinutes.toString());
+  }
+  if (referenceDate) {
+    searchParams.set('referenceDate', referenceDate);
+  }
+
+  const queryString = searchParams.toString();
+  const url = `${API_BASE_URL}/stats/weekly-recap${queryString ? `?${queryString}` : ''}`;
+
+  const response = await fetchWithAuth(url, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch weekly recap: ${response.status}`);
   }
 
   return response.json();

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -525,21 +525,8 @@ export interface RelativeEffortStatsResponse {
   currentWeekTotal: number;
 }
 
-export interface WeeklyRecapMetricInt {
-  current: number;
-  previous: number;
-  trailingAvg: number;
-  deltaVsPrevious: number;
-}
-
-export interface WeeklyRecapMetricLong {
-  current: number;
-  previous: number;
-  trailingAvg: number;
-  deltaVsPrevious: number;
-}
-
-export interface WeeklyRecapMetricDouble {
+/** Non-nullable week-over-week metric block (API uses int/long/double; JSON/TS are all number). */
+export interface WeeklyRecapNumericMetric {
   current: number;
   previous: number;
   trailingAvg: number;
@@ -561,11 +548,11 @@ export interface WeeklyRecapResponse {
   currentWeekIsPartial: boolean;
   generatedAtUtc: string;
   metrics: {
-    runs: WeeklyRecapMetricInt;
-    distanceM: WeeklyRecapMetricDouble;
-    durationS: WeeklyRecapMetricLong;
-    elevationGainM: WeeklyRecapMetricDouble;
-    relativeEffortSum: WeeklyRecapMetricInt;
+    runs: WeeklyRecapNumericMetric;
+    distanceM: WeeklyRecapNumericMetric;
+    durationS: WeeklyRecapNumericMetric;
+    elevationGainM: WeeklyRecapNumericMetric;
+    relativeEffortSum: WeeklyRecapNumericMetric;
     easyRunAvgHeartRateBpm: WeeklyRecapMetricNullableDouble;
   };
 }


### PR DESCRIPTION
- Implemented a new endpoint for retrieving weekly recap aggregates, including metrics for runs, distance, duration, elevation gain, relative effort, and easy run average heart rate.
- Introduced data models and aggregation logic to support the new endpoint.
- Added integration tests to validate the functionality of the weekly recap endpoint, ensuring accurate responses for various scenarios.
- Updated OpenAPI documentation to include the new endpoint and its parameters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new stats endpoint with non-trivial week-boundary/timezone calculations and multiple aggregate DB queries, which could cause subtle off-by-one or performance issues. Changes are otherwise additive and covered by new integration tests and updated client/OpenAPI docs.
> 
> **Overview**
> Adds a new authenticated `GET /stats/weekly-recap` endpoint that computes Monday–Sunday week windows (optionally anchored by `referenceDate` and shifted by `timezoneOffsetMinutes`) and returns **week-to-date** vs **previous week** totals plus trailing 3-week averages and week-over-week deltas for runs, distance, duration, elevation gain, relative effort, and duration-weighted easy-run average HR.
> 
> Updates integration tests to cover empty/invalid-input scenarios and correctness around null handling (elevation coalesce, relative-effort nulls, non-easy runs excluded from HR), and wires the endpoint into OpenAPI docs, a Bruno request, and the frontend API (`WeeklyRecapResponse` + `getWeeklyRecap`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abea19dad4e7290b6b05ca68db4ebb031a01cb36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->