### PR TITLE
feat: add RPE (Rate of Perceived Exertion) to workouts

### DIFF
--- a/api/Endpoints/WorkoutsEndpoints.cs
+++ b/api/Endpoints/WorkoutsEndpoints.cs
@@ -411,6 +411,7 @@ public static class WorkoutsEndpoints
                 avgPowerWatts = w.AvgPowerWatts,
                 calories = w.Calories,
                 relativeEffort = w.RelativeEffort,
+                rpe = w.Rpe,
                 runType = w.RunType,
                 source = w.Source,
                 device = w.Device,
@@ -1106,6 +1107,7 @@ public static class WorkoutsEndpoints
                 avgPowerWatts = workout.AvgPowerWatts,
                 calories = workout.Calories,
                 relativeEffort = workout.RelativeEffort,
+                rpe = workout.Rpe,
                 runType = workout.RunType,
                 notes = workout.Notes,
                 source = workout.Source,
@@ -1298,6 +1300,7 @@ public static class WorkoutsEndpoints
             avgPowerWatts = workout.AvgPowerWatts,
             calories = workout.Calories,
             relativeEffort = workout.RelativeEffort,
+            rpe = workout.Rpe,
             runType = workout.RunType,
             notes = workout.Notes,
             source = workout.Source,
@@ -2033,14 +2036,15 @@ public static class WorkoutsEndpoints
     /// Update workout
     /// </summary>
     /// <param name="id">Workout ID</param>
-    /// <param name="request">HTTP request containing JSON body with optional runType, notes, and/or name</param>
+    /// <param name="request">HTTP request containing JSON body with optional runType, notes, name, shoeId, and/or rpe</param>
     /// <param name="db">Database context</param>
     /// <param name="logger">Logger instance</param>
     /// <returns>Updated workout fields</returns>
     /// <remarks>
-    /// Updates workout RunType, Notes, and/or Name. All fields are optional - only provided fields are updated.
+    /// Updates workout RunType, Notes, Name, ShoeId, and/or Rpe. All fields are optional - only provided fields are updated.
     /// RunType must be one of: "Race", "Workout", "Long Run", "Easy Run", or null.
     /// Name must be 200 characters or less.
+    /// Rpe must be a whole number from 1 to 10, or null to clear.
     /// </remarks>
     private static async Task<IResult> UpdateWorkout(
         Guid id,
@@ -2174,15 +2178,43 @@ public static class WorkoutsEndpoints
             workout.ShoeId = shoeIdValue;
         }
 
+        // Validate and update Rpe if provided (1–10 scale, user-set)
+        if (root.TryGetProperty("rpe", out var rpeElement))
+        {
+            if (rpeElement.ValueKind == JsonValueKind.Null)
+            {
+                workout.Rpe = null;
+            }
+            else if (rpeElement.ValueKind == JsonValueKind.Number)
+            {
+                if (!rpeElement.TryGetInt32(out var rpeInt))
+                {
+                    return Results.BadRequest(new { error = "rpe must be a whole number between 1 and 10, or null" });
+                }
+
+                if (rpeInt < 1 || rpeInt > 10)
+                {
+                    return Results.BadRequest(new { error = "rpe must be between 1 and 10, or null" });
+                }
+
+                workout.Rpe = (byte)rpeInt;
+            }
+            else
+            {
+                return Results.BadRequest(new { error = "rpe must be a number between 1 and 10, or null" });
+            }
+        }
+
         // Save changes
         var runTypeUpdated = root.TryGetProperty("runType", out _);
         var notesUpdated = root.TryGetProperty("notes", out _);
         var nameUpdated = root.TryGetProperty("name", out _);
         var shoeIdUpdated = root.TryGetProperty("shoeId", out _);
+        var rpeUpdated = root.TryGetProperty("rpe", out _);
         await db.SaveChangesAsync();
 
-        logger.LogInformation("Updated workout {WorkoutId}: RunType={RunType}, RunTypeUpdated={RunTypeUpdated}, NotesUpdated={NotesUpdated}, NameUpdated={NameUpdated}, ShoeIdUpdated={ShoeIdUpdated}",
-            workout.Id, LogSanitizer.Sanitize(workout.RunType ?? "null"), runTypeUpdated, notesUpdated, nameUpdated, shoeIdUpdated);
+        logger.LogInformation("Updated workout {WorkoutId}: RunType={RunType}, RunTypeUpdated={RunTypeUpdated}, NotesUpdated={NotesUpdated}, NameUpdated={NameUpdated}, ShoeIdUpdated={ShoeIdUpdated}, RpeUpdated={RpeUpdated}",
+            workout.Id, LogSanitizer.Sanitize(workout.RunType ?? "null"), runTypeUpdated, notesUpdated, nameUpdated, shoeIdUpdated, rpeUpdated);
 
         return Results.Ok(new
         {
@@ -2190,7 +2222,8 @@ public static class WorkoutsEndpoints
             runType = workout.RunType,
             notes = workout.Notes,
             name = workout.Name,
-            shoeId = workout.ShoeId
+            shoeId = workout.ShoeId,
+            rpe = workout.Rpe
         });
         }
     }
@@ -2508,7 +2541,7 @@ public static class WorkoutsEndpoints
         .Produces(400)
         .Produces(404)
         .WithSummary("Update workout")
-        .WithDescription("Updates workout RunType, Notes, and/or Name");
+        .WithDescription("Updates workout RunType, Notes, Name, ShoeId, and/or Rpe (1–10)");
 
         group.MapDelete("/{id:guid}", DeleteWorkout)
         .WithName("DeleteWorkout")

--- a/api/Migrations/20260511200212_AddRpeToWorkout.Designer.cs
+++ b/api/Migrations/20260511200212_AddRpeToWorkout.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tempo.Api.Data;
@@ -11,9 +12,11 @@ using Tempo.Api.Data;
 namespace Tempo.Api.Migrations
 {
     [DbContext(typeof(TempoDbContext))]
-    partial class TempoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260511200212_AddRpeToWorkout")]
+    partial class AddRpeToWorkout
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20260511200212_AddRpeToWorkout.cs
+++ b/api/Migrations/20260511200212_AddRpeToWorkout.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tempo.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRpeToWorkout : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte>(
+                name: "Rpe",
+                table: "Workouts",
+                type: "smallint",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Rpe",
+                table: "Workouts");
+        }
+    }
+}

--- a/api/Models/Workout.cs
+++ b/api/Models/Workout.cs
@@ -66,6 +66,11 @@ public class Workout
     // Relative Effort (calculated from heart rate zones)
     public int? RelativeEffort { get; set; }
 
+    /// <summary>
+    /// Rate of Perceived Exertion (user-set, 1–10 scale). Not populated from import files.
+    /// </summary>
+    public byte? Rpe { get; set; }
+
     // ============================================
     // METADATA
     // ============================================

--- a/api/Services/DatabaseMigrationHelper.cs
+++ b/api/Services/DatabaseMigrationHelper.cs
@@ -50,7 +50,7 @@ public static class DatabaseMigrationHelper
         { ("Workouts", "Rpe"), "20260511200212_AddRpeToWorkout" }
     };
 
-    private const string ProductVersion = "9.0.10";
+    private const string ProductVersion = "10.0.0";
 
     /// <summary>
     /// Applies database migrations, handling edge cases where the database was created with EnsureCreated()

--- a/api/Services/DatabaseMigrationHelper.cs
+++ b/api/Services/DatabaseMigrationHelper.cs
@@ -45,7 +45,9 @@ public static class DatabaseMigrationHelper
         // AddShoeTracking migration
         { ("Workouts", "ShoeId"), "20251201120000_AddShoeTracking" },
         { ("UserSettings", "DefaultShoeId"), "20251201120000_AddShoeTracking" },
-        { ("Users", "SessionVersion"), "20260510120000_AddUserSessionVersion" }
+        { ("Users", "SessionVersion"), "20260510120000_AddUserSessionVersion" },
+        // AddRpeToWorkout migration
+        { ("Workouts", "Rpe"), "20260511200212_AddRpeToWorkout" }
     };
 
     private const string ProductVersion = "9.0.10";

--- a/api/Tempo.Api.Tests/IntegrationTests/WorkoutDetailsUpdateDeleteTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/WorkoutDetailsUpdateDeleteTests.cs
@@ -196,6 +196,7 @@ public class WorkoutDetailsUpdateDeleteTests : IClassFixture<TempoWebApplication
             workout.AvgPowerWatts = 250;
             workout.Calories = 500;
             workout.RelativeEffort = 150;
+            workout.Rpe = 7;
             
             await db.SaveChangesAsync();
         }
@@ -229,6 +230,7 @@ public class WorkoutDetailsUpdateDeleteTests : IClassFixture<TempoWebApplication
         result.AvgPowerWatts.Should().Be(250);
         result.Calories.Should().Be(500);
         result.RelativeEffort.Should().Be(150);
+        result.Rpe.Should().Be(7);
     }
 
     #endregion
@@ -344,6 +346,126 @@ public class WorkoutDetailsUpdateDeleteTests : IClassFixture<TempoWebApplication
             var updatedWorkout = await db.Workouts.FindAsync(workout.Id);
             updatedWorkout!.Notes.Should().Be("Test notes for workout");
         }
+    }
+
+    [Fact]
+    public async Task UpdateWorkout_UpdatesRpe_WhenValidValueProvided()
+    {
+        // Arrange
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Workout workout;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            workout = await TestDataSeeder.SeedWorkoutAsync(db);
+        }
+
+        var updateRequest = new { rpe = 8 };
+        var content = new StringContent(JsonSerializer.Serialize(updateRequest), Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await client.PatchAsync($"/workouts/{workout.Id}", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<UpdateWorkoutResponse>();
+        result.Should().NotBeNull();
+        result!.Rpe.Should().Be(8);
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            var updatedWorkout = await db.Workouts.FindAsync(workout.Id);
+            updatedWorkout!.Rpe.Should().Be(8);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateWorkout_ClearsRpe_WhenRpeIsNull()
+    {
+        // Arrange
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Workout workout;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            workout = await TestDataSeeder.SeedWorkoutAsync(db);
+            workout.Rpe = 5;
+            await db.SaveChangesAsync();
+        }
+
+        var updateRequest = new { rpe = (int?)null };
+        var content = new StringContent(JsonSerializer.Serialize(updateRequest), Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await client.PatchAsync($"/workouts/{workout.Id}", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<UpdateWorkoutResponse>();
+        result.Should().NotBeNull();
+        result!.Rpe.Should().BeNull();
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            var updatedWorkout = await db.Workouts.FindAsync(workout.Id);
+            updatedWorkout!.Rpe.Should().BeNull();
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(11)]
+    public async Task UpdateWorkout_Returns400_WhenRpeOutOfRange(int rpe)
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Workout workout;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            workout = await TestDataSeeder.SeedWorkoutAsync(db);
+        }
+
+        var updateRequest = new { rpe };
+        var content = new StringContent(JsonSerializer.Serialize(updateRequest), Encoding.UTF8, "application/json");
+
+        var response = await client.PatchAsync($"/workouts/{workout.Id}", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        error.Should().NotBeNull();
+        error!.Error.Should().Contain("rpe");
+    }
+
+    [Fact]
+    public async Task UpdateWorkout_Returns400_WhenRpeIsNotNumberOrNull()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Workout workout;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            workout = await TestDataSeeder.SeedWorkoutAsync(db);
+        }
+
+        var updateRequest = """{"rpe":"easy"}""";
+        var content = new StringContent(updateRequest, Encoding.UTF8, "application/json");
+
+        var response = await client.PatchAsync($"/workouts/{workout.Id}", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        error.Should().NotBeNull();
+        error!.Error.Should().Contain("rpe");
     }
 
     [Fact]
@@ -1013,6 +1135,7 @@ public class WorkoutDetailsUpdateDeleteTests : IClassFixture<TempoWebApplication
         public ushort? AvgPowerWatts { get; set; }
         public ushort? Calories { get; set; }
         public int? RelativeEffort { get; set; }
+        public byte? Rpe { get; set; }
         public string? RunType { get; set; }
         public string? Notes { get; set; }
         public string? Source { get; set; }
@@ -1051,6 +1174,7 @@ public class WorkoutDetailsUpdateDeleteTests : IClassFixture<TempoWebApplication
         public string? Notes { get; set; }
         public string? Name { get; set; }
         public string? ShoeId { get; set; }
+        public byte? Rpe { get; set; }
     }
 
     private class ErrorResponse

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1508,7 +1508,7 @@
           "Workouts"
         ],
         "summary": "Update workout",
-        "description": "Updates workout RunType, Notes, and/or Name. All fields are optional - only provided fields are updated.\nRunType must be one of: \"Race\", \"Workout\", \"Long Run\", \"Easy Run\", or null.\nName must be 200 characters or less.",
+        "description": "Updates workout RunType, Notes, Name, ShoeId, and/or Rpe. All fields are optional - only provided fields are updated.\nRunType must be one of: \"Race\", \"Workout\", \"Long Run\", \"Easy Run\", or null.\nName must be 200 characters or less.\nRpe must be a whole number from 1 to 10, or null to clear.",
         "operationId": "UpdateWorkout",
         "parameters": [
           {

--- a/frontend/app/dashboard/[id]/page.tsx
+++ b/frontend/app/dashboard/[id]/page.tsx
@@ -46,6 +46,7 @@ function WorkoutDetailPageContent() {
   const [selectedMediaIndex, setSelectedMediaIndex] = useState<number | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isEditingRunType, setIsEditingRunType] = useState(false);
+  const [isEditingRpe, setIsEditingRpe] = useState(false);
   const [isEditingNotes, setIsEditingNotes] = useState(false);
   const [isEditingShoe, setIsEditingShoe] = useState(false);
   const [notesValue, setNotesValue] = useState<string>('');
@@ -337,6 +338,83 @@ function WorkoutDetailPageContent() {
                     <span className="ml-2 text-xs text-red-600 dark:text-red-400">
                       Error: {updateWorkoutMutation.error instanceof Error ? updateWorkoutMutation.error.message : 'Failed to update'}
                     </span>
+                  )}
+                </dd>
+                  </div>
+
+                  {/* RPE (1–10) */}
+                  <div>
+                <dt className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">RPE (1–10)</dt>
+                <dd className="text-sm text-gray-900 dark:text-gray-100">
+                  {isEditingRpe ? (
+                    <div className="flex items-center gap-2">
+                      <select
+                        value={data.rpe != null ? String(data.rpe) : ''}
+                        onChange={(e) => {
+                          const newValue = e.target.value === '' ? null : Number(e.target.value);
+                          updateWorkoutMutation.mutate(
+                            { rpe: newValue },
+                            {
+                              onSuccess: () => {
+                                setIsEditingRpe(false);
+                              },
+                            }
+                          );
+                        }}
+                        disabled={updateWorkoutMutation.isPending}
+                        className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                        autoFocus
+                      >
+                        <option value="">None</option>
+                        {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => (
+                          <option key={n} value={n}>
+                            {n}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        onClick={() => setIsEditingRpe(false)}
+                        className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                        type="button"
+                        disabled={updateWorkoutMutation.isPending}
+                      >
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M6 18L18 6M6 6l12 12"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => setIsEditingRpe(true)}
+                      className="flex items-center gap-1 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                      type="button"
+                    >
+                      <span>{data.rpe != null ? String(data.rpe) : 'None'}</span>
+                      <svg
+                        className="w-4 h-4 opacity-50"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                        />
+                      </svg>
+                    </button>
                   )}
                 </dd>
                   </div>

--- a/frontend/hooks/useWorkoutMutations.ts
+++ b/frontend/hooks/useWorkoutMutations.ts
@@ -8,8 +8,13 @@ export function useWorkoutMutations(workoutId: string) {
   const queryClient = useQueryClient();
 
   const updateWorkoutMutation = useMutation({
-    mutationFn: (updates: { runType?: string | null; notes?: string | null; name?: string | null; shoeId?: string | null }) =>
-      updateWorkout(workoutId, updates),
+    mutationFn: (updates: {
+      runType?: string | null;
+      notes?: string | null;
+      name?: string | null;
+      shoeId?: string | null;
+      rpe?: number | null;
+    }) => updateWorkout(workoutId, updates),
     onSuccess: () => {
       invalidateWorkoutQueries(queryClient, workoutId);
     },

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -126,6 +126,7 @@ export interface WorkoutListItem {
   avgPowerWatts: number | null;
   calories: number | null;
   relativeEffort: number | null;
+  rpe: number | null;
   runType: string | null;
   source: string | null;
   device: string | null;
@@ -181,6 +182,7 @@ export interface WorkoutDetail {
   avgPowerWatts: number | null;
   calories: number | null;
   relativeEffort: number | null;
+  rpe: number | null;
   runType: string | null;
   notes: string | null;
   source: string | null;
@@ -801,6 +803,7 @@ export interface UpdateWorkoutRequest {
   notes?: string | null;
   name?: string | null;
   shoeId?: string | null;
+  rpe?: number | null;
 }
 
 export interface UpdateWorkoutResponse {
@@ -809,6 +812,7 @@ export interface UpdateWorkoutResponse {
   notes: string | null;
   name: string | null;
   shoeId: string | null;
+  rpe: number | null;
 }
 
 export async function updateWorkout(


### PR DESCRIPTION
- Introduced a new optional field `Rpe` to the Workout model, allowing users to set a perceived exertion level on a scale of 1 to 10.
- Updated the WorkoutsEndpoints to handle RPE in workout updates, including validation for input values.
- Enhanced OpenAPI documentation to reflect the new RPE parameter in workout update requests.
- Added integration tests to ensure proper functionality and validation of the RPE field during workout updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new nullable `Rpe` column and plumbs it through read/update APIs and the UI, which requires a database migration and touches core workout serialization. Risk is mainly around migration rollout and client/server contract compatibility for the new field.
> 
> **Overview**
> Adds an optional **Rate of Perceived Exertion** field (`rpe`, 1–10) to workouts end-to-end.
> 
> Backend now persists `Workout.Rpe` via a new EF migration, includes `rpe` in workout list/detail responses, and extends `PATCH /workouts/{id}` to accept/validate `rpe` (number 1–10 or `null`) and return it in the update payload; OpenAPI docs and integration tests are updated accordingly.
> 
> Frontend updates the workout detail page to display and inline-edit `rpe`, and expands the update mutation/API types to send/receive the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 481882d4234f7a09139bd1ca30aa53e1fc638025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->