### PR TITLE
Restore retired shoes on develop

### DIFF
--- a/api/Endpoints/SettingsEndpoints.cs
+++ b/api/Endpoints/SettingsEndpoints.cs
@@ -619,6 +619,11 @@ public static class SettingsEndpoints
                     return Results.NotFound(new { error = "Shoe not found" });
                 }
 
+                if (shoe.IsRetired)
+                {
+                    return Results.BadRequest(new { error = "Cannot set a retired shoe as the default shoe" });
+                }
+
                 settings.DefaultShoeId = request.DefaultShoeId.Value;
             }
             else

--- a/api/Endpoints/ShoesEndpoints.cs
+++ b/api/Endpoints/ShoesEndpoints.cs
@@ -11,20 +11,36 @@ namespace Tempo.Api.Endpoints;
 public static class ShoesEndpoints
 {
     /// <summary>
-    /// List all shoes with calculated mileage
+    /// List shoes with calculated mileage (active by default).
     /// </summary>
+    /// <param name="status">Filter: active (default), retired, or all</param>
     /// <param name="db">Database context</param>
     /// <param name="mileageService">Shoe mileage service</param>
     /// <param name="logger">Logger instance</param>
-    /// <returns>List of all shoes with total mileage</returns>
+    /// <returns>List of shoes with total mileage</returns>
     private static async Task<IResult> GetShoes(
+        string? status,
         TempoDbContext db,
         ShoeMileageService mileageService,
         ILogger<Program> logger)
     {
         try
         {
-            var shoes = await db.Shoes
+            var filter = (status ?? "active").Trim().ToLowerInvariant();
+            if (filter is not ("active" or "retired" or "all"))
+            {
+                return Results.BadRequest(new { error = "status must be active, retired, or all" });
+            }
+
+            var query = db.Shoes.AsQueryable();
+            query = filter switch
+            {
+                "active" => query.Where(s => !s.IsRetired),
+                "retired" => query.Where(s => s.IsRetired),
+                _ => query
+            };
+
+            var shoes = await query
                 .OrderBy(s => s.Brand)
                 .ThenBy(s => s.Model)
                 .ToListAsync();
@@ -43,6 +59,7 @@ public static class ShoesEndpoints
                     brand = shoe.Brand,
                     model = shoe.Model,
                     initialMileageM = shoe.InitialMileageM,
+                    isRetired = shoe.IsRetired,
                     totalMileage = totalMileage,
                     unit = unitPreference == "imperial" ? "miles" : "km",
                     createdAt = shoe.CreatedAt,
@@ -103,6 +120,7 @@ public static class ShoesEndpoints
                 Brand = request.Brand.Trim(),
                 Model = request.Model.Trim(),
                 InitialMileageM = request.InitialMileageM,
+                IsRetired = false,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow
             };
@@ -118,6 +136,7 @@ public static class ShoesEndpoints
                 brand = shoe.Brand,
                 model = shoe.Model,
                 initialMileageM = shoe.InitialMileageM,
+                isRetired = shoe.IsRetired,
                 createdAt = shoe.CreatedAt,
                 updatedAt = shoe.UpdatedAt
             });
@@ -259,6 +278,28 @@ public static class ShoesEndpoints
                 shoe.InitialMileageM = initialMileageValue;
             }
 
+            // Update IsRetired if provided
+            if (root.TryGetProperty("isRetired", out var isRetiredElement))
+            {
+                if (isRetiredElement.ValueKind != JsonValueKind.True && isRetiredElement.ValueKind != JsonValueKind.False)
+                {
+                    return Results.BadRequest(new { error = "isRetired must be a boolean" });
+                }
+
+                var newRetired = isRetiredElement.GetBoolean();
+                if (newRetired && !shoe.IsRetired)
+                {
+                    var settingsForRetire = await db.UserSettings.FirstOrDefaultAsync();
+                    if (settingsForRetire != null && settingsForRetire.DefaultShoeId == id)
+                    {
+                        settingsForRetire.DefaultShoeId = null;
+                        settingsForRetire.UpdatedAt = DateTime.UtcNow;
+                    }
+                }
+
+                shoe.IsRetired = newRetired;
+            }
+
             shoe.UpdatedAt = DateTime.UtcNow;
             await db.SaveChangesAsync();
 
@@ -270,6 +311,7 @@ public static class ShoesEndpoints
                 brand = shoe.Brand,
                 model = shoe.Model,
                 initialMileageM = shoe.InitialMileageM,
+                isRetired = shoe.IsRetired,
                 createdAt = shoe.CreatedAt,
                 updatedAt = shoe.UpdatedAt
             });
@@ -378,9 +420,10 @@ public static class ShoesEndpoints
         group.MapGet("", GetShoes)
             .WithName("GetShoes")
             .Produces(200)
+            .Produces(400)
             .Produces(500)
-            .WithSummary("List all shoes")
-            .WithDescription("Returns all shoes with calculated total mileage based on assigned workouts");
+            .WithSummary("List shoes")
+            .WithDescription("Returns shoes with calculated total mileage. Query status=active (default), retired, or all.");
 
         group.MapPost("", CreateShoe)
             .WithName("CreateShoe")
@@ -397,7 +440,7 @@ public static class ShoesEndpoints
             .Produces(404)
             .Produces(500)
             .WithSummary("Update a shoe")
-            .WithDescription("Updates shoe brand, model, and/or initial mileage");
+            .WithDescription("Updates shoe brand, model, initial mileage, and/or isRetired");
 
         group.MapDelete("/{id:guid}", DeleteShoe)
             .WithName("DeleteShoe")
@@ -456,6 +499,11 @@ public static class ShoesEndpoints
         /// Initial mileage in meters (optional)
         /// </summary>
         public double? InitialMileageM { get; set; }
+
+        /// <summary>
+        /// Whether the shoe is retired (optional)
+        /// </summary>
+        public bool? IsRetired { get; set; }
     }
 }
 

--- a/api/Endpoints/ShoesEndpoints.cs
+++ b/api/Endpoints/ShoesEndpoints.cs
@@ -120,7 +120,7 @@ public static class ShoesEndpoints
                 Brand = request.Brand.Trim(),
                 Model = request.Model.Trim(),
                 InitialMileageM = request.InitialMileageM,
-                IsRetired = false,
+                IsRetired = request.IsRetired ?? false,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow
             };
@@ -431,7 +431,7 @@ public static class ShoesEndpoints
             .Produces(400)
             .Produces(500)
             .WithSummary("Create a new shoe")
-            .WithDescription("Creates a new shoe with brand, model, and optional initial mileage");
+            .WithDescription("Creates a new shoe with brand, model, optional initial mileage, and optional isRetired (defaults to false)");
 
         group.MapPatch("/{id:guid}", UpdateShoe)
             .WithName("UpdateShoe")
@@ -478,6 +478,11 @@ public static class ShoesEndpoints
         /// Initial mileage in meters (optional)
         /// </summary>
         public double? InitialMileageM { get; set; }
+
+        /// <summary>
+        /// Whether the shoe is retired (optional, defaults to false)
+        /// </summary>
+        public bool? IsRetired { get; set; }
     }
 
     /// <summary>
@@ -499,11 +504,6 @@ public static class ShoesEndpoints
         /// Initial mileage in meters (optional)
         /// </summary>
         public double? InitialMileageM { get; set; }
-
-        /// <summary>
-        /// Whether the shoe is retired (optional)
-        /// </summary>
-        public bool? IsRetired { get; set; }
     }
 }
 

--- a/api/Endpoints/WorkoutsEndpoints.cs
+++ b/api/Endpoints/WorkoutsEndpoints.cs
@@ -1627,7 +1627,7 @@ public static class WorkoutsEndpoints
             {
                 // Verify the shoe still exists
                 var defaultShoe = await db.Shoes.FindAsync(settings.DefaultShoeId.Value);
-                if (defaultShoe != null)
+                if (defaultShoe != null && !defaultShoe.IsRetired)
                 {
                     foreach (var workout in workoutsToAdd)
                     {
@@ -2160,6 +2160,11 @@ public static class WorkoutsEndpoints
                     if (shoe == null)
                     {
                         return Results.BadRequest(new { error = "Shoe not found" });
+                    }
+
+                    if (shoe.IsRetired)
+                    {
+                        return Results.BadRequest(new { error = "Cannot assign a retired shoe to a workout" });
                     }
                 }
                 else
@@ -3377,7 +3382,7 @@ public static class WorkoutsEndpoints
             {
                 // Verify the shoe still exists
                 var defaultShoe = await db.Shoes.FindAsync(settings.DefaultShoeId.Value);
-                if (defaultShoe != null)
+                if (defaultShoe != null && !defaultShoe.IsRetired)
                 {
                     workout.ShoeId = settings.DefaultShoeId.Value;
                     logger.LogInformation("Assigned default shoe {ShoeId} to workout {WorkoutId}", settings.DefaultShoeId.Value, workout.Id);

--- a/api/Migrations/20260429231609_AddShoeIsRetired.Designer.cs
+++ b/api/Migrations/20260429231609_AddShoeIsRetired.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tempo.Api.Data;
@@ -11,54 +12,18 @@ using Tempo.Api.Data;
 namespace Tempo.Api.Migrations
 {
     [DbContext(typeof(TempoDbContext))]
-    partial class TempoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429231609_AddShoeIsRetired")]
+    partial class AddShoeIsRetired
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.0")
+                .HasAnnotation("ProductVersion", "9.0.10")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
-
-            modelBuilder.Entity("Tempo.Api.Models.ApiKey", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("KeyHash")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("KeyPrefix")
-                        .IsRequired()
-                        .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
-
-                    b.Property<string>("Label")
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
-
-                    b.Property<DateTime?>("RevokedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid>("UserId")
-                        .HasColumnType("uuid");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("KeyPrefix")
-                        .HasFilter("\"RevokedAt\" IS NULL");
-
-                    b.HasIndex("UserId");
-
-                    b.ToTable("ApiKeys");
-                });
 
             modelBuilder.Entity("Tempo.Api.Models.BestEffort", b =>
                 {
@@ -146,9 +111,6 @@ namespace Tempo.Api.Migrations
                     b.Property<string>("PasswordHash")
                         .IsRequired()
                         .HasColumnType("text");
-
-                    b.Property<int>("SessionVersion")
-                        .HasColumnType("integer");
 
                     b.Property<string>("Username")
                         .IsRequired()
@@ -330,9 +292,6 @@ namespace Tempo.Api.Migrations
 
                     b.Property<int?>("RelativeEffort")
                         .HasColumnType("integer");
-
-                    b.Property<byte?>("Rpe")
-                        .HasColumnType("smallint");
 
                     b.Property<string>("RunType")
                         .HasMaxLength(50)
@@ -517,17 +476,6 @@ namespace Tempo.Api.Migrations
                     b.ToTable("WorkoutTimeSeries");
                 });
 
-            modelBuilder.Entity("Tempo.Api.Models.ApiKey", b =>
-                {
-                    b.HasOne("Tempo.Api.Models.User", "User")
-                        .WithMany("ApiKeys")
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("User");
-                });
-
             modelBuilder.Entity("Tempo.Api.Models.BestEffort", b =>
                 {
                     b.HasOne("Tempo.Api.Models.Workout", "Workout")
@@ -606,11 +554,6 @@ namespace Tempo.Api.Migrations
             modelBuilder.Entity("Tempo.Api.Models.Shoe", b =>
                 {
                     b.Navigation("Workouts");
-                });
-
-            modelBuilder.Entity("Tempo.Api.Models.User", b =>
-                {
-                    b.Navigation("ApiKeys");
                 });
 
             modelBuilder.Entity("Tempo.Api.Models.Workout", b =>

--- a/api/Migrations/20260429231609_AddShoeIsRetired.cs
+++ b/api/Migrations/20260429231609_AddShoeIsRetired.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tempo.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddShoeIsRetired : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsRetired",
+                table: "Shoes",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsRetired",
+                table: "Shoes");
+        }
+    }
+}

--- a/api/Models/Shoe.cs
+++ b/api/Models/Shoe.cs
@@ -23,6 +23,8 @@ public class Shoe
 
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 
+    public bool IsRetired { get; set; }
+
     // Navigation properties
     public ICollection<Workout> Workouts { get; set; } = new List<Workout>();
 }

--- a/api/Services/DatabaseMigrationHelper.cs
+++ b/api/Services/DatabaseMigrationHelper.cs
@@ -45,6 +45,7 @@ public static class DatabaseMigrationHelper
         // AddShoeTracking migration
         { ("Workouts", "ShoeId"), "20251201120000_AddShoeTracking" },
         { ("UserSettings", "DefaultShoeId"), "20251201120000_AddShoeTracking" },
+        { ("Shoes", "IsRetired"), "20260429231609_AddShoeIsRetired" },
         { ("Users", "SessionVersion"), "20260510120000_AddUserSessionVersion" },
         // AddRpeToWorkout migration
         { ("Workouts", "Rpe"), "20260511200212_AddRpeToWorkout" }

--- a/api/Services/ImportService.cs
+++ b/api/Services/ImportService.cs
@@ -343,13 +343,22 @@ public class ImportService
                 existing.Zone5MaxBpm = settings.Zone5MaxBpm;
                 existing.UnitPreference = settings.UnitPreference;
                 
-                // Validate shoe reference if present
+                // Validate shoe reference if present (must exist and not be retired)
                 if (settings.DefaultShoeId.HasValue)
                 {
-                    var shoeExists = await _db.Shoes.AnyAsync(s => s.Id == settings.DefaultShoeId.Value);
-                    if (!shoeExists)
+                    var id = settings.DefaultShoeId.Value;
+                    var validDefault = await _db.Shoes.AnyAsync(s => s.Id == id && !s.IsRetired);
+                    if (!validDefault)
                     {
-                        result.Warnings.Add($"Settings references non-existent shoe {settings.DefaultShoeId}, clearing reference");
+                        if (await _db.Shoes.AnyAsync(s => s.Id == id && s.IsRetired))
+                        {
+                            result.Warnings.Add($"Settings references retired shoe {settings.DefaultShoeId}, clearing reference");
+                        }
+                        else
+                        {
+                            result.Warnings.Add($"Settings references non-existent shoe {settings.DefaultShoeId}, clearing reference");
+                        }
+
                         existing.DefaultShoeId = null;
                     }
                     else
@@ -380,13 +389,22 @@ public class ImportService
             }
             else
             {
-                // Validate shoe reference if present
+                // Validate shoe reference if present (must exist and not be retired)
                 if (settings.DefaultShoeId.HasValue)
                 {
-                    var shoeExists = await _db.Shoes.AnyAsync(s => s.Id == settings.DefaultShoeId.Value);
-                    if (!shoeExists)
+                    var id = settings.DefaultShoeId.Value;
+                    var validDefault = await _db.Shoes.AnyAsync(s => s.Id == id && !s.IsRetired);
+                    if (!validDefault)
                     {
-                        result.Warnings.Add($"Settings references non-existent shoe {settings.DefaultShoeId}, clearing reference");
+                        if (await _db.Shoes.AnyAsync(s => s.Id == id && s.IsRetired))
+                        {
+                            result.Warnings.Add($"Settings references retired shoe {settings.DefaultShoeId}, clearing reference");
+                        }
+                        else
+                        {
+                            result.Warnings.Add($"Settings references non-existent shoe {settings.DefaultShoeId}, clearing reference");
+                        }
+
                         settings.DefaultShoeId = null;
                     }
                 }

--- a/api/Tempo.Api.Tests/Infrastructure/TestDataSeeder.cs
+++ b/api/Tempo.Api.Tests/Infrastructure/TestDataSeeder.cs
@@ -44,18 +44,21 @@ public static class TestDataSeeder
     /// <param name="brand">Shoe brand (default: "Nike")</param>
     /// <param name="model">Shoe model (default: "Pegasus")</param>
     /// <param name="initialMileage">Initial mileage in meters (optional)</param>
+    /// <param name="isRetired">Whether the shoe is retired (default: false)</param>
     /// <returns>Created Shoe entity</returns>
     public static async Task<Shoe> SeedShoeAsync(
         TempoDbContext db,
         string brand = "Nike",
         string model = "Pegasus",
-        double? initialMileage = null)
+        double? initialMileage = null,
+        bool isRetired = false)
     {
         var shoe = new Shoe
         {
             Brand = brand,
             Model = model,
             InitialMileageM = initialMileage,
+            IsRetired = isRetired,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow
         };

--- a/api/Tempo.Api.Tests/IntegrationTests/ShoesEndpointsTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/ShoesEndpointsTests.cs
@@ -182,6 +182,32 @@ public class ShoesEndpointsTests : IClassFixture<TempoWebApplicationFactory>
     }
 
     [Fact]
+    public async Task CreateShoe_WithIsRetiredTrue_CreatesRetiredShoe()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+        var request = new
+        {
+            brand = "Nike",
+            model = "Retired Peg",
+            isRetired = true
+        };
+
+        var response = await client.PostAsJsonAsync("/shoes", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ShoeResponse>();
+        result.Should().NotBeNull();
+        result!.isRetired.Should().BeTrue();
+
+        var activeList = await client.GetFromJsonAsync<List<ShoeResponse>>("/shoes?status=active");
+        activeList.Should().NotContain(s => s.id == result.id);
+
+        var retiredList = await client.GetFromJsonAsync<List<ShoeResponse>>("/shoes?status=retired");
+        retiredList.Should().Contain(s => s.id == result.id);
+    }
+
+    [Fact]
     public async Task CreateShoe_WithMissingBrand_ReturnsBadRequest()
     {
         // Arrange

--- a/api/Tempo.Api.Tests/IntegrationTests/ShoesEndpointsTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/ShoesEndpointsTests.cs
@@ -64,6 +64,81 @@ public class ShoesEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         result[0].brand.Should().Be("Adidas"); // Sorted by brand
         result[1].brand.Should().Be("Nike");
         result[1].totalMileage.Should().BeApproximately(6.0, 0.001); // 1km initial + 5km workout = 6km
+        result.Should().OnlyContain(s => !s.isRetired);
+    }
+
+    [Fact]
+    public async Task GetShoes_StatusActive_ExcludesRetiredShoes()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            await TestDataSeeder.SeedShoeAsync(db, "Active", "One");
+            await TestDataSeeder.SeedShoeAsync(db, "Retired", "Two", isRetired: true);
+        }
+
+        var response = await client.GetAsync("/shoes");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<List<ShoeResponse>>();
+        result.Should().NotBeNull();
+        result!.Should().HaveCount(1);
+        result[0].brand.Should().Be("Active");
+    }
+
+    [Fact]
+    public async Task GetShoes_StatusRetired_ReturnsOnlyRetiredShoes()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            await TestDataSeeder.SeedShoeAsync(db, "Active", "One");
+            await TestDataSeeder.SeedShoeAsync(db, "Retired", "Two", isRetired: true);
+        }
+
+        var response = await client.GetAsync("/shoes?status=retired");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<List<ShoeResponse>>();
+        result.Should().NotBeNull();
+        result!.Should().HaveCount(1);
+        result[0].brand.Should().Be("Retired");
+        result[0].isRetired.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetShoes_StatusAll_ReturnsActiveAndRetired()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            await TestDataSeeder.SeedShoeAsync(db, "A", "One");
+            await TestDataSeeder.SeedShoeAsync(db, "B", "Two", isRetired: true);
+        }
+
+        var response = await client.GetAsync("/shoes?status=all");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<List<ShoeResponse>>();
+        result.Should().NotBeNull();
+        result!.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetShoes_InvalidStatus_ReturnsBadRequest()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        var response = await client.GetAsync("/shoes?status=invalid");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
@@ -103,6 +178,7 @@ public class ShoesEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         result.model.Should().Be("Pegasus 40");
         result.initialMileageM.Should().Be(1000.0);
         result.id.Should().NotBeEmpty();
+        result.isRetired.Should().BeFalse();
     }
 
     [Fact]
@@ -307,6 +383,54 @@ public class ShoesEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         result!.brand.Should().Be("Nike"); // Unchanged
         result.model.Should().Be("Pegasus 40"); // Updated
         result.initialMileageM.Should().Be(1000.0); // Unchanged
+    }
+
+    [Fact]
+    public async Task UpdateShoe_SetIsRetired_ClearsDefaultShoe()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Shoe shoe;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            shoe = await TestDataSeeder.SeedShoeAsync(db, "Nike", "Pegasus");
+            await TestDataSeeder.SeedUserSettingsAsync(db, defaultShoeId: shoe.Id);
+        }
+
+        var response = await client.PatchAsJsonAsync($"/shoes/{shoe.Id}", new { isRetired = true });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<ShoeResponse>();
+        body.Should().NotBeNull();
+        body!.isRetired.Should().BeTrue();
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            var settings = await db.UserSettings.FirstOrDefaultAsync();
+            settings.Should().NotBeNull();
+            settings!.DefaultShoeId.Should().BeNull();
+        }
+    }
+
+    [Fact]
+    public async Task SetDefaultShoe_WithRetiredShoe_ReturnsBadRequest()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Shoe shoe;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            shoe = await TestDataSeeder.SeedShoeAsync(db, "Nike", "Old", isRetired: true);
+        }
+
+        var response = await client.PutAsJsonAsync("/settings/default-shoe", new { defaultShoeId = shoe.Id });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
@@ -544,6 +668,7 @@ public class ShoesEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         public string brand { get; set; } = string.Empty;
         public string model { get; set; } = string.Empty;
         public double? initialMileageM { get; set; }
+        public bool isRetired { get; set; }
         public double totalMileage { get; set; }
         public string unit { get; set; } = string.Empty;
         public DateTime createdAt { get; set; }

--- a/api/Tempo.Api.Tests/IntegrationTests/WorkoutDetailsUpdateDeleteTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/WorkoutDetailsUpdateDeleteTests.cs
@@ -506,6 +506,29 @@ public class WorkoutDetailsUpdateDeleteTests : IClassFixture<TempoWebApplication
     }
 
     [Fact]
+    public async Task UpdateWorkout_Returns400_WhenShoeIsRetired()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Workout workout;
+        Shoe shoe;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            workout = await TestDataSeeder.SeedWorkoutAsync(db);
+            shoe = await TestDataSeeder.SeedShoeAsync(db, brand: "Nike", model: "Old", isRetired: true);
+        }
+
+        var updateRequest = new { shoeId = shoe.Id.ToString() };
+        var content = new StringContent(JsonSerializer.Serialize(updateRequest), Encoding.UTF8, "application/json");
+
+        var response = await client.PatchAsync($"/workouts/{workout.Id}", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task UpdateWorkout_RemovesShoeAssignment_WhenShoeIdIsNull()
     {
         // Arrange

--- a/api/Tempo.Api.Tests/Services/ExportServiceTests.cs
+++ b/api/Tempo.Api.Tests/Services/ExportServiceTests.cs
@@ -379,6 +379,31 @@ public class ExportServiceTests : IClassFixture<TempoWebApplicationFactory>, IDi
     /// <summary>
     /// Cleans the database before a test to ensure accurate statistics
     /// </summary>
+    [Fact]
+    public async Task ExportAllDataAsync_ShoesJsonIncludesIsRetired()
+    {
+        await CleanDatabaseAsync();
+        await TestDataSeeder.SeedShoeAsync(_db, "Nike", "Active");
+        await TestDataSeeder.SeedShoeAsync(_db, "Adidas", "Retired", isRetired: true);
+
+        using var zipStream = new MemoryStream();
+        await _exportService.ExportAllDataAsync(zipStream);
+        zipStream.Position = 0;
+
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        var shoesEntry = archive.GetEntry("data/shoes.json");
+        shoesEntry.Should().NotBeNull();
+        using var shoesStream = shoesEntry!.Open();
+        var shoesJson = await new StreamReader(shoesStream).ReadToEndAsync();
+        var shoes = JsonSerializer.Deserialize<List<JsonElement>>(shoesJson);
+        shoes.Should().NotBeNull();
+        shoes!.Should().HaveCount(2);
+        var retired = shoes.Single(e => e.GetProperty("brand").GetString() == "Adidas");
+        retired.GetProperty("isRetired").GetBoolean().Should().BeTrue();
+        var active = shoes.Single(e => e.GetProperty("brand").GetString() == "Nike");
+        active.GetProperty("isRetired").GetBoolean().Should().BeFalse();
+    }
+
     private async Task CleanDatabaseAsync()
     {
         // Delete in order to respect foreign key constraints

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -461,12 +461,25 @@
         "tags": [
           "Shoes"
         ],
-        "summary": "List all shoes with calculated mileage",
-        "description": "Returns all shoes with calculated total mileage based on assigned workouts",
+        "summary": "List shoes with calculated mileage (active by default).",
+        "description": "Returns shoes with calculated total mileage. Query status=active (default), retired, or all.",
         "operationId": "GetShoes",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter: active (default), retired, or all",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
           },
           "500": {
             "description": "Internal Server Error"
@@ -483,7 +496,7 @@
           "Shoes"
         ],
         "summary": "Create a new shoe",
-        "description": "Creates a new shoe with brand, model, and optional initial mileage",
+        "description": "Creates a new shoe with brand, model, optional initial mileage, and optional isRetired (defaults to false)",
         "operationId": "CreateShoe",
         "requestBody": {
           "description": "Create shoe request",
@@ -520,7 +533,7 @@
           "Shoes"
         ],
         "summary": "Update a shoe",
-        "description": "Updates shoe brand, model, and/or initial mileage",
+        "description": "Updates shoe brand, model, initial mileage, and/or isRetired",
         "operationId": "UpdateShoe",
         "parameters": [
           {
@@ -1800,6 +1813,11 @@
             "type": "number",
             "description": "Initial mileage in meters (optional)",
             "format": "double",
+            "nullable": true
+          },
+          "isRetired": {
+            "type": "boolean",
+            "description": "Whether the shoe is retired (optional, defaults to false)",
             "nullable": true
           }
         },

--- a/frontend/app/dashboard/[id]/page.tsx
+++ b/frontend/app/dashboard/[id]/page.tsx
@@ -427,6 +427,7 @@ function WorkoutDetailPageContent() {
                     <div className="flex items-center gap-2">
                       <ShoeSelector
                         value={data.shoeId}
+                        assignedShoe={data.shoe}
                         onChange={(shoeId) => {
                           updateWorkoutMutation.mutate(
                             { shoeId },

--- a/frontend/app/settings/shoes/retired/page.tsx
+++ b/frontend/app/settings/shoes/retired/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import Link from 'next/link';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getShoes, updateShoe } from '@/lib/api';
+import { AuthGuard } from '@/components/AuthGuard';
+
+function RetiredShoesContent() {
+  const queryClient = useQueryClient();
+  const { data: shoes, isLoading } = useQuery({
+    queryKey: ['shoes', 'retired'],
+    queryFn: () => getShoes({ status: 'retired' }),
+  });
+
+  const unretireMutation = useMutation({
+    mutationFn: (id: string) => updateShoe(id, { isRetired: false }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['shoes'] });
+      queryClient.invalidateQueries({ queryKey: ['default-shoe'] });
+    },
+  });
+
+  return (
+    <div className="flex min-h-screen items-start justify-center bg-zinc-50 dark:bg-black">
+      <main className="flex min-h-screen w-full max-w-4xl flex-col items-start py-16 px-8">
+        <div className="w-full mb-8">
+          <p className="mb-2">
+            <Link
+              href="/settings"
+              className="text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+            >
+              ← Back to Settings
+            </Link>
+          </p>
+          <h1 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-2">Retired shoes</h1>
+          <p className="text-lg text-gray-600 dark:text-gray-400">
+            Shoes you retired stay here with their mileage. Un-retire to use them in lists again.
+          </p>
+        </div>
+
+        <div className="w-full bg-white dark:bg-gray-900 p-6 rounded-lg border border-gray-200 dark:border-gray-800">
+          {isLoading ? (
+            <p className="text-gray-600 dark:text-gray-400">Loading…</p>
+          ) : !shoes?.length ? (
+            <p className="text-gray-600 dark:text-gray-400">No retired shoes.</p>
+          ) : (
+            <ul className="space-y-4">
+              {shoes.map((shoe) => (
+                <li
+                  key={shoe.id}
+                  className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
+                >
+                  <div>
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                      {shoe.brand} {shoe.model}
+                    </h2>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      Total: {shoe.totalMileage.toFixed(1)} {shoe.unit}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => unretireMutation.mutate(shoe.id)}
+                    disabled={unretireMutation.isPending}
+                    className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 disabled:opacity-50 shrink-0"
+                  >
+                    {unretireMutation.isPending ? 'Saving…' : 'Un-retire'}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default function RetiredShoesPage() {
+  return (
+    <AuthGuard>
+      <RetiredShoesContent />
+    </AuthGuard>
+  );
+}

--- a/frontend/components/ShoeManagementSection.tsx
+++ b/frontend/components/ShoeManagementSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getShoes,
@@ -50,8 +51,8 @@ export function ShoeManagementSection() {
   };
 
   const { data: shoes, isLoading } = useQuery({
-    queryKey: ['shoes'],
-    queryFn: getShoes,
+    queryKey: ['shoes', 'active'],
+    queryFn: () => getShoes({ status: 'active' }),
   });
 
   const { data: defaultShoe } = useQuery({
@@ -120,6 +121,16 @@ export function ShoeManagementSection() {
     }
   };
 
+  const handleRetire = (id: string) => {
+    if (
+      window.confirm(
+        'Retire this shoe? It will no longer appear in lists or as an option for new workouts. Past workouts keep their assignment. You can un-retire it later from Retired shoes.'
+      )
+    ) {
+      updateMutation.mutate({ id, data: { isRetired: true } });
+    }
+  };
+
   const handleSetDefault = (id: string | null) => {
     setDefaultMutation.mutate(id);
   };
@@ -155,8 +166,16 @@ export function ShoeManagementSection() {
       <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
         Shoe Management
       </h2>
-      <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+      <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">
         Track mileage on your running shoes. Assign shoes to workouts to automatically calculate total mileage.
+      </p>
+      <p className="text-sm mb-6">
+        <Link
+          href="/settings/shoes/retired"
+          className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 underline"
+        >
+          View retired shoes and mileage
+        </Link>
       </p>
 
       {/* Default Shoe Selector */}
@@ -338,12 +357,20 @@ export function ShoeManagementSection() {
                         </span>
                       )}
                     </div>
-                    <div className="flex gap-2">
+                    <div className="flex flex-wrap gap-2 justify-end">
                       <button
                         onClick={() => startEdit(shoe)}
                         className="px-3 py-1 text-sm bg-gray-200 text-gray-700 rounded hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
                       >
                         Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleRetire(shoe.id)}
+                        disabled={updateMutation.isPending}
+                        className="px-3 py-1 text-sm bg-amber-100 text-amber-900 rounded hover:bg-amber-200 dark:bg-amber-900/40 dark:text-amber-100 dark:hover:bg-amber-900/60 disabled:opacity-50"
+                      >
+                        Retire
                       </button>
                       <button
                         onClick={() => handleDelete(shoe.id)}

--- a/frontend/components/ShoeManagementSection.tsx
+++ b/frontend/components/ShoeManagementSection.tsx
@@ -71,12 +71,23 @@ export function ShoeManagementSection() {
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: UpdateShoeRequest }) => updateShoe(id, data),
-    onSuccess: () => {
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: UpdateShoeRequest;
+      /** When false, leave the edit form open (e.g. retiring a different shoe than the one being edited). */
+      resetEditForm?: boolean;
+    }) => updateShoe(id, data),
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['shoes'] });
       queryClient.invalidateQueries({ queryKey: ['default-shoe'] });
-      setEditingId(null);
-      setEditShoe({ brand: '', model: '', initialMileageM: null });
+      if (variables.resetEditForm !== false) {
+        setEditingId(null);
+        setEditShoe({ brand: '', model: '', initialMileageM: null });
+        setEditShoeInitialMileageInput('');
+      }
     },
   });
 
@@ -127,7 +138,7 @@ export function ShoeManagementSection() {
         'Retire this shoe? It will no longer appear in lists or as an option for new workouts. Past workouts keep their assignment. You can un-retire it later from Retired shoes.'
       )
     ) {
-      updateMutation.mutate({ id, data: { isRetired: true } });
+      updateMutation.mutate({ id, data: { isRetired: true }, resetEditForm: false });
     }
   };
 

--- a/frontend/components/ShoeSelector.tsx
+++ b/frontend/components/ShoeSelector.tsx
@@ -8,12 +8,14 @@ interface ShoeSelectorProps {
   onChange: (shoeId: string | null) => void;
   showMileage?: boolean;
   className?: string;
+  /** When the workout is assigned a retired shoe, pass it so the select can show the current value. */
+  assignedShoe?: { id: string; brand: string; model: string } | null;
 }
 
-export function ShoeSelector({ value, onChange, showMileage = false, className = '' }: ShoeSelectorProps) {
+export function ShoeSelector({ value, onChange, showMileage = false, className = '', assignedShoe = null }: ShoeSelectorProps) {
   const { data: shoes, isLoading } = useQuery({
-    queryKey: ['shoes'],
-    queryFn: getShoes,
+    queryKey: ['shoes', 'active'],
+    queryFn: () => getShoes({ status: 'active' }),
   });
 
   if (isLoading) {
@@ -31,6 +33,12 @@ export function ShoeSelector({ value, onChange, showMileage = false, className =
     return `${shoe.brand} ${shoe.model}`;
   };
 
+  const showRetiredAssigned =
+    !!value &&
+    !!assignedShoe &&
+    assignedShoe.id === value &&
+    !shoes?.some((s) => s.id === value);
+
   return (
     <select
       value={value || ''}
@@ -38,6 +46,11 @@ export function ShoeSelector({ value, onChange, showMileage = false, className =
       className={className}
     >
       <option value="">None</option>
+      {showRetiredAssigned && assignedShoe && (
+        <option key={assignedShoe.id} value={assignedShoe.id}>
+          {assignedShoe.brand} {assignedShoe.model} (retired)
+        </option>
+      )}
       {shoes?.map((shoe) => (
         <option key={shoe.id} value={shoe.id}>
           {formatShoeLabel(shoe)}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1232,6 +1232,7 @@ export interface CreateShoeRequest {
   brand: string;
   model: string;
   initialMileageM?: number | null;
+  isRetired?: boolean;
 }
 
 export interface UpdateShoeRequest {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1213,6 +1213,7 @@ export interface Shoe {
   brand: string;
   model: string;
   initialMileageM: number | null;
+  isRetired: boolean;
   totalMileage: number;
   unit: 'km' | 'miles';
   createdAt: string;
@@ -1237,6 +1238,7 @@ export interface UpdateShoeRequest {
   brand?: string;
   model?: string;
   initialMileageM?: number | null;
+  isRetired?: boolean;
 }
 
 export interface ShoeMileageResponse {
@@ -1251,16 +1253,22 @@ export interface DefaultShoeResponse {
   model?: string;
 }
 
+export type ShoesListStatus = 'active' | 'retired' | 'all';
+
 // Shoe API functions
-export async function getShoes(): Promise<Shoe[]> {
-  const response = await fetchWithAuth(`${API_BASE_URL}/shoes`, {
+export async function getShoes(params?: { status?: ShoesListStatus }): Promise<Shoe[]> {
+  const status = params?.status ?? 'active';
+  const qs = new URLSearchParams({ status });
+  const response = await fetchWithAuth(`${API_BASE_URL}/shoes?${qs.toString()}`, {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch shoes: ${response.status}`);
+    const err = await response.json().catch(() => null);
+    const msg = err && typeof err === 'object' && 'error' in err ? String((err as { error: string }).error) : `Failed to fetch shoes: ${response.status}`;
+    throw new Error(msg);
   }
 
   return response.json();


### PR DESCRIPTION
## Summary

Re-applies shoe retirement from [#139](https://github.com/trevordavies095/tempo/pull/139) onto current `develop`. That PR merged in April, but its commits are no longer in `develop`'s history (branch diverged), so `:edge` images never shipped this feature.

Cherry-picked the original three commits onto latest `develop`:
- `b50191d` — retirement API/UI and validation rules
- `9dd7f45` — `AddShoeIsRetired` EF migration
- `5b161ea` — shoe update mutation `resetEditForm` for retire flow

One conflict resolved in `DatabaseMigrationHelper.cs` (kept `IsRetired` alongside `SessionVersion` and `Rpe` column mappings).

### Behavior (unchanged from #139)

- **`Shoe.IsRetired`** with migration; existing rows default to not retired
- **`GET /shoes`**: `status` query (`active` | `retired` | `all`); responses include `isRetired`
- **`PATCH /shoes/{id}`**: `isRetired`; retiring clears default shoe when applicable
- **`PUT /settings/default-shoe`** and workout assign/import paths reject retired shoes
- **Frontend**: Retire action, `/settings/shoes/retired`, `ShoeSelector` shows assigned retired shoe as "(retired)"

## Test plan

- [x] `dotnet build` (api)
- [x] `dotnet test --filter FullyQualifiedName~ShoesEndpoints` (27 passed)
- [ ] After merge: pull `:edge` images and verify Retire / Retired shoes page in settings
- [ ] Run `dotnet ef database update` on existing DBs (migration `20260429231609_AddShoeIsRetired`)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new persisted `Shoe.IsRetired` state with an EF migration and threads it through multiple API validation paths (default shoe, workout assignment, imports), which could affect existing clients and data flows if assumptions about shoe availability change.
> 
> **Overview**
> Adds first-class **shoe retirement** via a new `Shoe.IsRetired` column (EF migration) and propagates this state through the system.
> 
> `GET /shoes` now supports `status=active|retired|all` (defaulting to active) and returns `isRetired`; create/update responses also include `isRetired`, and `POST /shoes` can set it. Retiring a shoe via `PATCH /shoes/{id}` clears `UserSettings.DefaultShoeId` when applicable, and the API now rejects using retired shoes as the default shoe or assigning them to workouts (including default-shoe auto-assignment and import validation).
> 
> Frontend updates shoe queries to request only active shoes by default, adds a retire action plus a new `/settings/shoes/retired` page to view/un-retire shoes, and updates `ShoeSelector` to still display an already-assigned retired shoe as “(retired)”. Tests and `openapi.json` are updated to cover the new retirement behavior and schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6db60406b72e5081b72859476e56fb4d77138cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->