### PR TITLE
Reskin the command-center WebUI and add workout highlight

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -57,3 +57,27 @@ body {
   background: var(--canvas);
   color: var(--ink);
 }
+
+input[type='radio'],
+input[type='checkbox'],
+input[type='range'] {
+  accent-color: var(--volt);
+}
+
+input[type='number'],
+input[type='text'],
+input[type='password'],
+input[type='email'],
+select,
+textarea {
+  color-scheme: light;
+}
+
+.dark input[type='number'],
+.dark input[type='text'],
+.dark input[type='password'],
+.dark input[type='email'],
+.dark select,
+.dark textarea {
+  color-scheme: dark;
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -20,20 +20,20 @@ export default function Home() {
 
   // Show loading state while checking
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-black">
+    <div className="flex min-h-screen items-center justify-center bg-canvas">
       <main className="flex min-h-screen w-full max-w-4xl flex-col items-center justify-start py-16 px-8">
         <div className="w-full mb-8">
           <div>
-            <h1 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+            <h1 className="text-4xl font-bold text-ink mb-2">
               Tempo
             </h1>
-            <p className="text-lg text-gray-600 dark:text-gray-400">
+            <p className="text-lg text-muted">
               Self-hostable running tracker
             </p>
           </div>
         </div>
         <div className="w-full text-center">
-          <p className="text-gray-600 dark:text-gray-400">Loading...</p>
+          <p className="text-muted">Loading...</p>
         </div>
       </main>
     </div>

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -34,6 +34,9 @@ import {
   getPasswordLengthAndBytesError,
 } from '@/lib/passwordPolicy';
 
+const fieldClass =
+  'w-full px-3 py-2 border border-border rounded-tempo bg-canvas text-ink focus:outline-none focus:ring-2 focus:ring-volt';
+
 function SettingsPageContent() {
   const queryClient = useQueryClient();
   const [hrZones, setHrZones] = useState<HeartRateZoneSettings | null>(null);
@@ -336,7 +339,7 @@ function SettingsPageContent() {
                 <>
                   {/* Calculation Method Selection */}
                   <div className="mb-6">
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+                    <label className="block text-sm font-medium text-ink mb-3">
                       Calculation Method
                     </label>
                     <div className="space-y-2">
@@ -347,9 +350,9 @@ function SettingsPageContent() {
                           value="AgeBased"
                           checked={calculationMethod === 'AgeBased'}
                           onChange={(e) => setCalculationMethod(e.target.value as HeartRateCalculationMethod)}
-                          className="mr-2"
+                          className="mr-2 h-4 w-4 accent-[var(--volt)]"
                         />
-                        <span className="text-sm text-gray-700 dark:text-gray-300">
+                        <span className="text-sm text-ink">
                           220 - Age (Default)
                         </span>
                       </label>
@@ -360,9 +363,9 @@ function SettingsPageContent() {
                           value="Karvonen"
                           checked={calculationMethod === 'Karvonen'}
                           onChange={(e) => setCalculationMethod(e.target.value as HeartRateCalculationMethod)}
-                          className="mr-2"
+                          className="mr-2 h-4 w-4 accent-[var(--volt)]"
                         />
-                        <span className="text-sm text-gray-700 dark:text-gray-300">
+                        <span className="text-sm text-ink">
                           Karvonen (Heart Rate Reserve)
                         </span>
                       </label>
@@ -373,9 +376,9 @@ function SettingsPageContent() {
                           value="Custom"
                           checked={calculationMethod === 'Custom'}
                           onChange={(e) => setCalculationMethod(e.target.value as HeartRateCalculationMethod)}
-                          className="mr-2"
+                          className="mr-2 h-4 w-4 accent-[var(--volt)]"
                         />
-                        <span className="text-sm text-gray-700 dark:text-gray-300">
+                        <span className="text-sm text-ink">
                           Custom Zones
                         </span>
                       </label>
@@ -385,7 +388,7 @@ function SettingsPageContent() {
                   {/* Input Fields Based on Method */}
                   {calculationMethod === 'AgeBased' && (
                     <div className="mb-6">
-                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      <label className="block text-sm font-medium text-ink mb-2">
                         Age
                       </label>
                       <input
@@ -394,9 +397,9 @@ function SettingsPageContent() {
                         max="120"
                         value={age}
                         onChange={(e) => setAge(parseInt(e.target.value) || 30)}
-                        className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+                        className={fieldClass}
                       />
-                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      <p className="text-xs text-muted mt-1">
                         Max HR will be calculated as 220 - age = {220 - age} BPM
                       </p>
                     </div>
@@ -405,7 +408,7 @@ function SettingsPageContent() {
                   {calculationMethod === 'Karvonen' && (
                     <div className="mb-6 space-y-4">
                       <div>
-                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                        <label className="block text-sm font-medium text-ink mb-2">
                           Resting Heart Rate (BPM)
                         </label>
                         <input
@@ -414,11 +417,11 @@ function SettingsPageContent() {
                           max="120"
                           value={restingHr}
                           onChange={(e) => setRestingHr(parseInt(e.target.value) || 60)}
-                          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+                          className={fieldClass}
                         />
                       </div>
                       <div>
-                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                        <label className="block text-sm font-medium text-ink mb-2">
                           Maximum Heart Rate (BPM)
                         </label>
                         <input
@@ -427,9 +430,9 @@ function SettingsPageContent() {
                           max="250"
                           value={maxHr}
                           onChange={(e) => setMaxHr(parseInt(e.target.value) || 190)}
-                          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+                          className={fieldClass}
                         />
-                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                        <p className="text-xs text-muted mt-1">
                           Heart Rate Reserve = {maxHr} - {restingHr} = {maxHr - restingHr} BPM
                         </p>
                       </div>
@@ -438,13 +441,13 @@ function SettingsPageContent() {
 
                   {calculationMethod === 'Custom' && (
                     <div className="mb-6">
-                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+                      <label className="block text-sm font-medium text-ink mb-3">
                         Custom Zone Boundaries (BPM)
                       </label>
                       <div className="space-y-3">
                         {customZones.map((zone, index) => (
                           <div key={index} className="flex items-center gap-3">
-                            <span className="text-sm font-medium text-gray-700 dark:text-gray-300 w-16">
+                            <span className="text-sm font-medium text-ink w-16">
                               Zone {index + 1}:
                             </span>
                             <input
@@ -453,17 +456,17 @@ function SettingsPageContent() {
                               max="250"
                               value={zone.min}
                               onChange={(e) => updateCustomZone(index, 'min', parseInt(e.target.value) || 0)}
-                              className="w-24 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+                              className={`w-24 ${fieldClass}`}
                               placeholder="Min"
                             />
-                            <span className="text-gray-500 dark:text-gray-400">-</span>
+                            <span className="text-muted">-</span>
                             <input
                               type="number"
                               min="30"
                               max="250"
                               value={zone.max}
                               onChange={(e) => updateCustomZone(index, 'max', parseInt(e.target.value) || 0)}
-                              className="w-24 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+                              className={`w-24 ${fieldClass}`}
                               placeholder="Max"
                             />
                           </div>
@@ -473,17 +476,17 @@ function SettingsPageContent() {
                   )}
 
                   {/* Zone Preview */}
-                  <div className="bg-gray-50 dark:bg-gray-800 p-4 rounded-lg mb-6">
-                    <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+                  <div className="bg-canvas border border-border p-4 rounded-tempo mb-6">
+                    <h3 className="text-sm font-semibold text-ink mb-3">
                       Zone Preview
                     </h3>
                     <div className="space-y-2">
                       {displayZones.map((zone, index) => (
                         <div key={index} className="flex items-center justify-between text-sm">
-                          <span className="text-gray-700 dark:text-gray-300 font-medium">
+                          <span className="text-ink font-medium">
                             Zone {index + 1}
                           </span>
-                          <span className="text-gray-600 dark:text-gray-400">
+                          <span className="text-muted">
                             {zone.min} - {zone.max} BPM
                           </span>
                         </div>
@@ -501,12 +504,12 @@ function SettingsPageContent() {
                         {isSaving ? 'Saving...' : 'Save Heart Rate Zones'}
                       </Button>
                       {saveSuccess && (
-                        <span className="text-sm text-green-600 dark:text-green-400">
+                        <span className="text-sm text-ink">
                           Settings saved successfully!
                         </span>
                       )}
                       {saveError && (
-                        <span className="text-sm text-red-600 dark:text-red-400">
+                        <span className="text-sm text-danger">
                           {saveError}
                         </span>
                       )}
@@ -548,12 +551,12 @@ function SettingsPageContent() {
                   {isRecalculatingSplits ? 'Recalculating...' : 'Recalculate Splits'}
                 </Button>
                 {recalcSplitsSuccess && (
-                  <span className="text-sm text-green-600 dark:text-green-400">
+                  <span className="text-sm text-ink">
                     Successfully recalculated splits for {recalcSplitsWorkoutCount} workout{recalcSplitsWorkoutCount !== 1 ? 's' : ''}!
                   </span>
                 )}
                 {recalcSplitsError && (
-                  <span className="text-sm text-red-600 dark:text-red-400">
+                  <span className="text-sm text-danger">
                     {recalcSplitsError}
                   </span>
                 )}
@@ -579,12 +582,12 @@ function SettingsPageContent() {
                     {isRecalculating ? 'Recalculating...' : 'Recalculate Relative Effort'}
                   </Button>
                   {recalcSuccess && (
-                    <span className="text-sm text-green-600 dark:text-green-400">
+                    <span className="text-sm text-ink">
                       Successfully recalculated relative effort for {recalcWorkoutCount} workout{recalcWorkoutCount !== 1 ? 's' : ''}!
                     </span>
                   )}
                   {recalcError && (
-                    <span className="text-sm text-red-600 dark:text-red-400">
+                    <span className="text-sm text-danger">
                       {recalcError}
                     </span>
                   )}
@@ -617,7 +620,7 @@ function SettingsPageContent() {
                   </p>
                   <form onSubmit={handleChangePassword} className="flex flex-col gap-4 max-w-md">
                     <div>
-                      <label htmlFor="settings-current-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      <label htmlFor="settings-current-password" className="block text-sm font-medium text-ink mb-1">
                         Current password
                       </label>
                       <input
@@ -627,11 +630,11 @@ function SettingsPageContent() {
                         autoComplete="current-password"
                         value={currentPassword}
                         onChange={(e) => setCurrentPassword(e.target.value)}
-                        className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100"
+                        className={fieldClass}
                       />
                     </div>
                     <div>
-                      <label htmlFor="settings-new-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      <label htmlFor="settings-new-password" className="block text-sm font-medium text-ink mb-1">
                         New password
                       </label>
                       <input
@@ -641,11 +644,11 @@ function SettingsPageContent() {
                         autoComplete="new-password"
                         value={newPassword}
                         onChange={(e) => setNewPassword(e.target.value)}
-                        className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100"
+                        className={fieldClass}
                       />
                     </div>
                     <div>
-                      <label htmlFor="settings-confirm-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      <label htmlFor="settings-confirm-password" className="block text-sm font-medium text-ink mb-1">
                         Confirm new password
                       </label>
                       <input
@@ -655,7 +658,7 @@ function SettingsPageContent() {
                         autoComplete="new-password"
                         value={confirmPassword}
                         onChange={(e) => setConfirmPassword(e.target.value)}
-                        className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100"
+                        className={fieldClass}
                       />
                     </div>
                     <Button
@@ -666,10 +669,10 @@ function SettingsPageContent() {
                       {passwordChangeSaving ? 'Updating…' : 'Update password'}
                     </Button>
                     {passwordChangeSuccess && (
-                      <p className="text-sm text-green-600 dark:text-green-400">Password updated successfully.</p>
+                      <p className="text-sm text-ink">Password updated successfully.</p>
                     )}
                     {passwordChangeError && (
-                      <p className="text-sm text-red-600 dark:text-red-400">{passwordChangeError}</p>
+                      <p className="text-sm text-danger">{passwordChangeError}</p>
                     )}
                   </form>
                 </div>

--- a/frontend/components/AuthGuard.tsx
+++ b/frontend/components/AuthGuard.tsx
@@ -17,7 +17,7 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="text-gray-600">Loading...</div>
+        <div className="text-muted">Loading...</div>
       </div>
     );
   }

--- a/frontend/components/CropWorkoutDialog.tsx
+++ b/frontend/components/CropWorkoutDialog.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { formatDuration, formatDistance } from '@/lib/format';
 import type { WorkoutDetail } from '@/lib/api';
 import { useSettings } from '@/lib/settings';
+import { Button } from '@/components/ui/Button';
 
 interface CropWorkoutDialogProps {
   open: boolean;
@@ -153,42 +154,42 @@ export function CropWorkoutDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
       onClick={handleBackdropClick}
     >
-      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl max-w-2xl w-full p-6 border border-gray-200 dark:border-gray-800">
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
+      <div className="bg-raised rounded-lg shadow-xl max-w-2xl w-full p-6 border border-border">
+        <h2 className="text-xl font-semibold text-ink mb-4">
           Crop Workout
         </h2>
 
         <div className="mb-6 space-y-4">
-          <p className="text-sm text-gray-600 dark:text-gray-400">
+          <p className="text-sm text-muted">
             Trim time from the beginning or end of your workout. The original data will be preserved for audit trail.
           </p>
 
           {/* Timeline Visualization */}
           <div className="relative">
-            <div className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+            <div className="text-xs text-muted mb-2">
               Timeline (drag handles to adjust)
             </div>
-            <div className="relative h-12 bg-gray-200 dark:bg-gray-700 rounded-lg overflow-hidden">
+            <div className="relative h-12 bg-canvas rounded-lg overflow-hidden">
               {/* Trimmed start section */}
               {startTrimSeconds > 0 && (
                 <div
-                  className="absolute left-0 top-0 h-full bg-red-300 dark:bg-red-900/50"
+                  className="absolute left-0 top-0 h-full bg-danger/40"
                   style={{ width: `${(startTrimSeconds / originalDurationS) * 100}%` }}
                 />
               )}
               {/* Trimmed end section */}
               {endTrimSeconds > 0 && (
                 <div
-                  className="absolute right-0 top-0 h-full bg-red-300 dark:bg-red-900/50"
+                  className="absolute right-0 top-0 h-full bg-danger/40"
                   style={{ width: `${(endTrimSeconds / originalDurationS) * 100}%` }}
                 />
               )}
               {/* Remaining section */}
               <div
-                className="absolute left-0 top-0 h-full bg-green-300 dark:bg-green-900/50"
+                className="absolute left-0 top-0 h-full bg-ink/20 dark:bg-volt/30"
                 style={{
                   left: `${(startTrimSeconds / originalDurationS) * 100}%`,
                   width: `${(newDurationS / originalDurationS) * 100}%`,
@@ -215,7 +216,7 @@ export function CropWorkoutDialog({
                 style={{ pointerEvents: 'auto' }}
               />
             </div>
-            <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-1">
+            <div className="flex justify-between text-xs text-muted mt-1">
               <span>Start</span>
               <span>End</span>
             </div>
@@ -226,7 +227,7 @@ export function CropWorkoutDialog({
                 <button
                   onClick={handleStartBack}
                   disabled={startTrimSeconds === 0}
-                  className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-gray-100 dark:disabled:hover:bg-gray-800"
+                  className="px-3 py-1.5 text-sm font-medium rounded-tempo transition-colors bg-canvas text-ink hover:bg-raised disabled:opacity-50 disabled:cursor-not-allowed"
                   title="Move start point later (trim less from start)"
                 >
                   ← Back
@@ -234,7 +235,7 @@ export function CropWorkoutDialog({
                 <button
                   onClick={handleStartForward}
                   disabled={startTrimSeconds >= maxStartTrim}
-                  className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-gray-100 dark:disabled:hover:bg-gray-800"
+                  className="px-3 py-1.5 text-sm font-medium rounded-tempo transition-colors bg-canvas text-ink hover:bg-raised disabled:opacity-50 disabled:cursor-not-allowed"
                   title="Move start point earlier (trim more from start)"
                 >
                   Forward →
@@ -245,7 +246,7 @@ export function CropWorkoutDialog({
                 <button
                   onClick={handleEndBack}
                   disabled={endTrimSeconds >= maxEndTrim}
-                  className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-gray-100 dark:disabled:hover:bg-gray-800"
+                  className="px-3 py-1.5 text-sm font-medium rounded-tempo transition-colors bg-canvas text-ink hover:bg-raised disabled:opacity-50 disabled:cursor-not-allowed"
                   title="Move end point earlier (trim more from end)"
                 >
                   ← Back
@@ -253,7 +254,7 @@ export function CropWorkoutDialog({
                 <button
                   onClick={handleEndForward}
                   disabled={endTrimSeconds === 0}
-                  className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-gray-100 dark:disabled:hover:bg-gray-800"
+                  className="px-3 py-1.5 text-sm font-medium rounded-tempo transition-colors bg-canvas text-ink hover:bg-raised disabled:opacity-50 disabled:cursor-not-allowed"
                   title="Move end point later (trim less from end)"
                 >
                   Forward →
@@ -265,7 +266,7 @@ export function CropWorkoutDialog({
           {/* Trim Inputs */}
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label className="block text-sm font-medium text-ink mb-1">
                 Trim from Start
               </label>
               <div className="flex gap-2">
@@ -274,15 +275,15 @@ export function CropWorkoutDialog({
                   value={startTrimInput}
                   onChange={(e) => handleStartTrimInputChange(e.target.value)}
                   placeholder="M:SS"
-                  className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="flex-1 px-3 py-2 border border-border rounded-md bg-canvas text-ink focus:outline-none focus:ring-2 focus:ring-volt"
                 />
-                <div className="px-3 py-2 text-sm text-gray-600 dark:text-gray-400">
+                <div className="px-3 py-2 text-sm text-muted">
                   {formatDuration(startTrimSeconds)}
                 </div>
               </div>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label className="block text-sm font-medium text-ink mb-1">
                 Trim from End
               </label>
               <div className="flex gap-2">
@@ -291,9 +292,9 @@ export function CropWorkoutDialog({
                   value={endTrimInput}
                   onChange={(e) => handleEndTrimInputChange(e.target.value)}
                   placeholder="M:SS"
-                  className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="flex-1 px-3 py-2 border border-border rounded-md bg-canvas text-ink focus:outline-none focus:ring-2 focus:ring-volt"
                 />
-                <div className="px-3 py-2 text-sm text-gray-600 dark:text-gray-400">
+                <div className="px-3 py-2 text-sm text-muted">
                   {formatDuration(endTrimSeconds)}
                 </div>
               </div>
@@ -301,49 +302,48 @@ export function CropWorkoutDialog({
           </div>
 
           {/* Preview */}
-          <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-            <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Preview</div>
+          <div className="bg-canvas rounded-lg p-4 border border-border">
+            <div className="text-sm font-medium text-ink mb-2">Preview</div>
             <div className="grid grid-cols-2 gap-4 text-sm">
               <div>
-                <div className="text-gray-500 dark:text-gray-400">Original</div>
-                <div className="font-semibold text-gray-900 dark:text-gray-100">
+                <div className="text-muted">Original</div>
+                <div className="font-semibold text-ink">
                   {formatDuration(originalDurationS)} • {formatDistance(originalDistanceM, unitPreference)}
                 </div>
               </div>
               <div>
-                <div className="text-gray-500 dark:text-gray-400">After Crop</div>
-                <div className="font-semibold text-gray-900 dark:text-gray-100">
+                <div className="text-muted">After Crop</div>
+                <div className="font-semibold text-ink">
                   {formatDuration(newDurationS)} • {formatDistance(newDistanceM, unitPreference)}
                 </div>
               </div>
             </div>
             {!isValid && newDurationS < MINIMUM_REMAINING_DURATION_SECONDS && (
-              <div className="mt-2 text-xs text-red-600 dark:text-red-400">
+              <div className="mt-2 text-xs text-danger">
                 Minimum remaining duration is {formatDuration(MINIMUM_REMAINING_DURATION_SECONDS)}
               </div>
             )}
           </div>
 
-          <p className="text-xs text-red-600 dark:text-red-400 font-medium">
+          <p className="text-xs text-danger font-medium">
             This action cannot be undone. Original data will be preserved for audit trail.
           </p>
         </div>
 
         <div className="flex gap-3 justify-end">
-          <button
+          <Button
+            variant="secondary"
             onClick={onClose}
             disabled={isLoading}
-            className="px-4 py-2 rounded-lg font-medium transition-colors bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={handleConfirm}
             disabled={!isValid || isLoading}
-            className="px-4 py-2 rounded-lg font-medium transition-colors bg-blue-600 text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isLoading ? 'Cropping...' : 'Crop Workout'}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/components/ExportImportSection.tsx
+++ b/frontend/components/ExportImportSection.tsx
@@ -66,7 +66,7 @@ export function ExportImportSection() {
               {isExporting ? 'Exporting...' : 'Export All Data'}
             </Button>
             {exportSuccess && (
-              <span className="text-sm text-green-600 dark:text-green-400">
+              <span className="text-sm text-ink">
                 Export completed successfully! Your download should start shortly.
               </span>
             )}

--- a/frontend/components/MediaModal.tsx
+++ b/frontend/components/MediaModal.tsx
@@ -116,7 +116,7 @@ export function MediaModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
       onClick={handleBackdropClick}
     >
       <div className="relative max-w-7xl max-h-[90vh] w-full h-full flex items-center justify-center">
@@ -133,7 +133,7 @@ export function MediaModal({
         <button
           onClick={handleDelete}
           disabled={deleteMutation.isPending}
-          className="absolute top-4 right-20 z-10 p-2 bg-red-600 hover:bg-red-700 disabled:bg-red-800 disabled:opacity-50 rounded-full text-white transition-colors"
+          className="absolute top-4 right-20 z-10 p-2 bg-danger text-on-danger hover:opacity-90 disabled:opacity-50 rounded-full transition-opacity"
           aria-label="Delete media"
           title="Delete media (Delete key)"
         >
@@ -188,7 +188,7 @@ export function MediaModal({
               onError={() => setIsLoading(false)}
             />
           ) : (
-            <div className="bg-gray-800 p-8 rounded-lg text-white">
+            <div className="bg-raised p-8 rounded-tempo text-ink">
               <p>Unsupported media type: {currentMedia.mimeType}</p>
             </div>
           )}

--- a/frontend/components/MediaUpload.tsx
+++ b/frontend/components/MediaUpload.tsx
@@ -4,6 +4,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useCallback, useState, useEffect, useRef } from 'react';
 import { uploadWorkoutMedia } from '@/lib/api';
 import { IconPlus, IconX } from '@tabler/icons-react';
+import { Button } from '@/components/ui/Button';
 
 interface MediaUploadProps {
   workoutId: string;
@@ -86,7 +87,7 @@ export function MediaUpload({ workoutId, onUploadSuccess }: MediaUploadProps) {
         <button
           type="button"
           onClick={handleButtonClick}
-          className="text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors flex items-center gap-1.5"
+          className="text-sm text-muted hover:text-ink transition-colors flex items-center gap-1.5"
         >
           <IconPlus className="w-4 h-4" />
           <span>Add Media</span>
@@ -109,48 +110,48 @@ export function MediaUpload({ workoutId, onUploadSuccess }: MediaUploadProps) {
               {selectedFiles.map((file, index) => (
                 <div
                   key={`${file.name}-${index}`}
-                  className="flex items-center justify-between p-2 bg-white dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-700"
+                  className="flex items-center justify-between p-2 bg-canvas rounded border border-border"
                 >
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm text-gray-900 dark:text-gray-100 truncate">
+                    <p className="text-sm text-ink truncate">
                       {file.name}
                     </p>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                    <p className="text-xs text-muted">
                       {formatFileSize(file.size)}
                     </p>
                   </div>
                   <button
                     type="button"
                     onClick={() => handleRemoveFile(index)}
-                    className="ml-2 text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                    className="ml-2 text-muted hover:text-danger transition-colors"
                   >
                     <IconX className="w-5 h-5" />
                   </button>
                 </div>
               ))}
             </div>
-            <button
+            <Button
               type="submit"
               disabled={mutation.isPending}
-              className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium"
+              className="w-full"
             >
               {mutation.isPending ? 'Uploading...' : `Upload ${selectedFiles.length} file${selectedFiles.length > 1 ? 's' : ''}`}
-            </button>
+            </Button>
           </div>
         )}
 
         {/* Success/Error messages */}
         {mutation.isSuccess && (
-          <div className="p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
-            <p className="text-sm text-green-800 dark:text-green-200">
+          <div className="p-3 bg-canvas border border-border rounded-tempo">
+            <p className="text-sm text-ink">
               Media uploaded successfully!
             </p>
           </div>
         )}
 
         {mutation.isError && (
-          <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
-            <p className="text-sm text-red-800 dark:text-red-200">
+          <div className="p-3 bg-canvas border border-danger rounded-tempo">
+            <p className="text-sm text-danger">
               Error: {mutation.error instanceof Error ? mutation.error.message : 'Unknown error'}
             </p>
           </div>

--- a/frontend/components/RelativeEffortGraph.tsx
+++ b/frontend/components/RelativeEffortGraph.tsx
@@ -174,7 +174,10 @@ export default function RelativeEffortGraph() {
       <div className="relative">
         <div style={{ height: '180px', marginBottom: '0px' }}>
           <ResponsiveContainer width="100%" height="100%">
-            <ComposedChart data={chartData} margin={{ top: 0, right: 0, left: -20, bottom: 20 }}>
+            <ComposedChart
+              data={chartData}
+              margin={{ top: 8, right: 16, left: 4, bottom: 36 }}
+            >
             <defs>
               <linearGradient id="rangeGradient" x1="0" y1="0" x2="0" y2="1">
                 <stop offset="0%" stopColor="var(--muted)" stopOpacity={0.25} />
@@ -208,21 +211,21 @@ export default function RelativeEffortGraph() {
                 return null;
               }}
             />
-            <XAxis 
-              dataKey="day" 
+            <XAxis
+              dataKey="day"
               type="category"
               axisLine={false}
               tickLine={false}
               tick={<CustomTick />}
-              padding={{ left: 0, right: 0 }}
+              padding={{ left: 12, right: 12 }}
             />
-            <YAxis 
+            <YAxis
               domain={[0, adjustedYAxisMax]}
               axisLine={false}
               tickLine={false}
               tick={{ fill: 'var(--muted)', fontSize: 12 }}
-              width={50}
-              tickMargin={5}
+              width={40}
+              tickMargin={8}
               ticks={yAxisTicks}
               allowDecimals={false}
             />

--- a/frontend/components/RouteComparisonTab.tsx
+++ b/frontend/components/RouteComparisonTab.tsx
@@ -184,24 +184,24 @@ function PaceComparisonTooltip({
 
   if (dataFromLabel) {
     return (
-      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
-        <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
+      <div className="bg-canvas border border-border rounded-lg shadow-lg p-3">
+        <p className="text-sm font-medium text-ink mb-1">
           {dataFromLabel.dateISO ? formatDate(dataFromLabel.dateISO) : dataFromLabel.dateDisplay}
         </p>
-        <p className="text-xs text-gray-600 dark:text-gray-400">
+        <p className="text-xs text-muted">
           Pace: {dataFromLabel.paceDisplay}
         </p>
-        <p className="text-xs text-gray-600 dark:text-gray-400">
+        <p className="text-xs text-muted">
           Duration: {formatDuration(dataFromLabel.durationS)}
         </p>
         {dataFromLabel.timeDifferenceS !== undefined && dataFromLabel.timeDifferenceS !== null && (
           <p
             className={`text-xs ${
               dataFromLabel.timeDifferenceS < 0
-                ? 'text-green-600 dark:text-green-400'
+                ? 'text-ink'
                 : dataFromLabel.timeDifferenceS > 0
-                  ? 'text-red-600 dark:text-red-400'
-                  : 'text-gray-500 dark:text-gray-400'
+                  ? 'text-danger'
+                  : 'text-muted'
             }`}
           >
             {formatTimeDifference(dataFromLabel.timeDifferenceS)}
@@ -215,9 +215,9 @@ function PaceComparisonTooltip({
     ?.payload as TrendLinePoint | undefined;
   if (trendPayload) {
     return (
-      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
-        <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">Linear trend</p>
-        <p className="text-xs text-gray-600 dark:text-gray-400">
+      <div className="bg-canvas border border-border rounded-lg shadow-lg p-3">
+        <p className="text-sm font-medium text-ink mb-1">Linear trend</p>
+        <p className="text-xs text-muted">
           Pace: {formatPace(trendPayload.paceS, unitPreference)}
         </p>
       </div>
@@ -385,9 +385,9 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
   if (isLoading) {
     return (
       <div className="w-full space-y-3">
-        <div className="bg-white dark:bg-gray-900 p-6 rounded-lg border border-gray-200 dark:border-gray-800">
+        <div className="bg-raised p-6 rounded-lg border border-border">
           <div className="h-64 flex items-center justify-center">
-            <p className="text-sm text-gray-600 dark:text-gray-400">Loading route comparison...</p>
+            <p className="text-sm text-muted">Loading route comparison...</p>
           </div>
         </div>
       </div>
@@ -398,9 +398,9 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
   if (isError) {
     return (
       <div className="w-full space-y-3">
-        <div className="bg-white dark:bg-gray-900 p-6 rounded-lg border border-gray-200 dark:border-gray-800">
-          <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
-            <p className="text-sm text-red-800 dark:text-red-200">
+        <div className="bg-raised p-6 rounded-lg border border-border">
+          <div className="p-4 bg-canvas border border-danger rounded-tempo">
+            <p className="text-sm text-danger">
               {error instanceof Error ? error.message : 'Unable to load route comparison. Please try again.'}
             </p>
           </div>
@@ -413,9 +413,9 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
   if (chartData.length === 0) {
     return (
       <div className="w-full space-y-3">
-        <div className="bg-white dark:bg-gray-900 p-6 rounded-lg border border-gray-200 dark:border-gray-800">
-          <div className="p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+        <div className="bg-raised p-6 rounded-lg border border-border">
+          <div className="p-4 bg-canvas rounded-lg border border-border">
+            <p className="text-sm text-muted">
               No previous efforts found on this route.
             </p>
           </div>
@@ -427,21 +427,20 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
   return (
     <div className="w-full space-y-3">
       {/* Chart Section */}
-      <div className="bg-white dark:bg-gray-900 p-6 rounded-lg border border-gray-200 dark:border-gray-800">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+      <div className="bg-raised p-6 rounded-lg border border-border">
+        <h2 className="text-lg font-semibold text-ink mb-4">
           Pace Over Time
         </h2>
         <div style={{ height: '300px' }}>
           <ResponsiveContainer width="100%" height="100%">
             <ComposedChart data={chartData} margin={{ top: 5, right: 20, left: 0, bottom: 20 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" className="dark:stroke-gray-700" />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--line)" />
               <XAxis 
                 dataKey="date" 
                 type="number"
                 scale="time"
                 domain={['dataMin', 'dataMax']}
-                tick={{ fill: '#6b7280', fontSize: 12 }}
-                className="dark:text-gray-400"
+                tick={{ fill: 'var(--muted)', fontSize: 12 }}
                 angle={-45}
                 textAnchor="end"
                 height={80}
@@ -452,8 +451,7 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
                 }}
               />
               <YAxis 
-                tick={{ fill: '#6b7280', fontSize: 12 }}
-                className="dark:text-gray-400"
+                tick={{ fill: 'var(--muted)', fontSize: 12 }}
                 tickFormatter={(value) => formatPace(value, unitPreference)}
                 domain={['auto', 'auto']}
                 width={80}
@@ -474,7 +472,7 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
                 name="Efforts"
                 data={chartData}
                 dataKey="paceS"
-                fill="#8884d8"
+                fill="var(--muted)"
                 isAnimationActive={false}
                 shape={(props: unknown) => {
                   const { cx, cy, payload } = props as {
@@ -492,8 +490,8 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
                       cx={cx}
                       cy={cy}
                       r={isCurrent ? 6 : 4}
-                      fill={isCurrent ? '#3b82f6' : '#8884d8'}
-                      stroke={isCurrent ? '#1e40af' : 'none'}
+                      fill={isCurrent ? 'var(--volt)' : 'var(--muted)'}
+                      stroke={isCurrent ? 'var(--ink)' : 'none'}
                       strokeWidth={isCurrent ? 2 : 0}
                       style={{ cursor: 'pointer' }}
                       onClick={(e) => {
@@ -520,8 +518,8 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
                       cx={cx}
                       cy={cy}
                       r={8}
-                      fill="#8884d8"
-                      stroke="#fff"
+                      fill="var(--volt)"
+                      stroke="var(--ink)"
                       strokeWidth={2}
                       style={{ cursor: 'pointer' }}
                       onClick={(e) => {
@@ -539,8 +537,8 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
                   type="linear"
                   data={trendLineData}
                   dataKey="paceS"
-                  stroke="#9ca3af"
-                  className="dark:stroke-gray-500 [&_path]:pointer-events-none"
+                  stroke="var(--muted)"
+                  className="[&_path]:pointer-events-none"
                   strokeWidth={2}
                   strokeDasharray="6 4"
                   dot={false}
@@ -556,24 +554,24 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
 
       {/* Quick Stats Section */}
       {quickStats && (
-        <div className="bg-white dark:bg-gray-900 p-6 rounded-lg border border-gray-200 dark:border-gray-800">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+        <div className="bg-raised p-6 rounded-lg border border-border">
+          <h2 className="text-lg font-semibold text-ink mb-4">
             Quick Stats
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {/* Best Time */}
             {quickStats.bestTime && quickStats.bestTime.timeDifferenceS !== undefined && quickStats.bestTime.timeDifferenceS !== null && (
-              <div className="p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
-                <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Best Time</div>
-                <div className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">
+              <div className="p-4 bg-canvas rounded-lg border border-border">
+                <div className="text-xs font-medium text-muted mb-1">Best Time</div>
+                <div className="text-sm font-semibold text-ink mb-1">
                   {formatDate(quickStats.bestTime.startedAt)}
                 </div>
                 <div className={`text-xs ${
                   quickStats.bestTime.timeDifferenceS < 0
-                    ? 'text-green-600 dark:text-green-400'
+                    ? 'text-ink'
                     : quickStats.bestTime.timeDifferenceS > 0
-                    ? 'text-red-600 dark:text-red-400'
-                    : 'text-gray-500 dark:text-gray-400'
+                    ? 'text-danger'
+                    : 'text-muted'
                 }`}>
                   {formatTimeDifference(quickStats.bestTime.timeDifferenceS)}
                 </div>
@@ -581,22 +579,22 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
             )}
 
             {/* Average Pace */}
-            <div className="p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
-              <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Average Pace</div>
-              <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            <div className="p-4 bg-canvas rounded-lg border border-border">
+              <div className="text-xs font-medium text-muted mb-1">Average Pace</div>
+              <div className="text-sm font-semibold text-ink">
                 {formatPace(quickStats.avgPace, unitPreference)}
               </div>
             </div>
 
             {/* Improvement Trend */}
-            <div className="p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
-              <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Trend</div>
+            <div className="p-4 bg-canvas rounded-lg border border-border">
+              <div className="text-xs font-medium text-muted mb-1">Trend</div>
               <div className={`text-sm font-semibold flex items-center gap-1 ${
                 quickStats.trend === 'improving'
-                  ? 'text-green-600 dark:text-green-400'
+                  ? 'text-ink'
                   : quickStats.trend === 'declining'
-                  ? 'text-red-600 dark:text-red-400'
-                  : 'text-gray-600 dark:text-gray-400'
+                  ? 'text-danger'
+                  : 'text-muted'
               }`}>
                 {quickStats.trend === 'improving' && '↑ Improving'}
                 {quickStats.trend === 'declining' && '↓ Declining'}
@@ -608,16 +606,16 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
       )}
 
       {/* Sortable List Section */}
-      <div className="bg-white dark:bg-gray-900 p-6 rounded-lg border border-gray-200 dark:border-gray-800">
+      <div className="bg-raised p-6 rounded-lg border border-border">
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          <h2 className="text-lg font-semibold text-ink">
             All Matches ({sortedRoutes.length})
           </h2>
           <div className="flex items-center gap-2">
             <select
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as SortBy)}
-              className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="px-3 py-1.5 text-sm border border-border rounded-md bg-canvas text-ink focus:outline-none focus:ring-2 focus:ring-volt"
             >
               <option value="date">Date</option>
               <option value="pace">Pace</option>
@@ -625,7 +623,7 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
             </select>
             <button
               onClick={() => setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')}
-              className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="px-3 py-1.5 text-sm border border-border rounded-md bg-canvas text-ink hover:bg-canvas focus:outline-none focus:ring-2 focus:ring-volt"
               aria-label={`Sort ${sortOrder === 'asc' ? 'descending' : 'ascending'}`}
             >
               {sortOrder === 'asc' ? '↑' : '↓'}
@@ -637,32 +635,32 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
             <Link
               key={route.workoutId}
               href={`/dashboard/${route.workoutId}`}
-              className="block p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-colors"
+              className="block p-4 bg-canvas rounded-lg border border-border hover:bg-canvas hover:border-ink transition-colors"
             >
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
                 {/* Date */}
                 <div>
-                  <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Date</div>
-                  <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                  <div className="text-xs text-muted mb-1">Date</div>
+                  <div className="text-sm font-semibold text-ink">
                     {formatDate(route.startedAt)}
                   </div>
                 </div>
 
                 {/* Duration with time difference */}
                 <div>
-                  <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Duration</div>
+                  <div className="text-xs text-muted mb-1">Duration</div>
                   <div className="flex items-center gap-1.5">
-                    <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                    <span className="text-sm font-semibold text-ink">
                       {formatDuration(route.durationS)}
                     </span>
                     {route.timeDifferenceS !== undefined && route.timeDifferenceS !== null && (
                       <span
                         className={`text-xs ${
                           route.timeDifferenceS < 0
-                            ? 'text-green-600 dark:text-green-400'
+                            ? 'text-ink'
                             : route.timeDifferenceS > 0
-                            ? 'text-red-600 dark:text-red-400'
-                            : 'text-gray-500 dark:text-gray-400'
+                            ? 'text-danger'
+                            : 'text-muted'
                         }`}
                       >
                         {formatTimeDifference(route.timeDifferenceS)}
@@ -673,19 +671,19 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
 
                 {/* Pace with pace difference */}
                 <div>
-                  <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Pace</div>
+                  <div className="text-xs text-muted mb-1">Pace</div>
                   <div className="flex items-center gap-1.5">
-                    <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                    <span className="text-sm font-semibold text-ink">
                       {formatPace(route.avgPaceS, unitPreference)}
                     </span>
                     {route.paceDifferenceS !== undefined && route.paceDifferenceS !== null && (
                       <span
                         className={`text-xs ${
                           route.paceDifferenceS < 0
-                            ? 'text-green-600 dark:text-green-400'
+                            ? 'text-ink'
                             : route.paceDifferenceS > 0
-                            ? 'text-red-600 dark:text-red-400'
-                            : 'text-gray-500 dark:text-gray-400'
+                            ? 'text-danger'
+                            : 'text-muted'
                         }`}
                       >
                         {formatPaceDifference(route.paceDifferenceS, unitPreference)}
@@ -696,17 +694,17 @@ export function RouteComparisonTab({ workoutId, currentWorkout }: RouteCompariso
 
                 {/* Distance and Additional Info */}
                 <div>
-                  <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Distance</div>
-                  <div className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                  <div className="text-xs text-muted mb-1">Distance</div>
+                  <div className="text-sm font-semibold text-ink mb-2">
                     {formatDistance(route.distanceM, unitPreference)}
                   </div>
                   {route.relativeEffort !== null && route.relativeEffort !== undefined && (
-                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                    <div className="text-xs text-muted">
                       Effort: {route.relativeEffort}
                     </div>
                   )}
                   {route.elevGainM !== null && route.elevGainM !== undefined && (
-                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                    <div className="text-xs text-muted">
                       Elev: {formatElevation(route.elevGainM, unitPreference)}
                     </div>
                   )}

--- a/frontend/components/RouteMatchesSummary.tsx
+++ b/frontend/components/RouteMatchesSummary.tsx
@@ -151,13 +151,13 @@ export function RouteMatchesSummary({ workoutId, currentWorkout }: RouteMatchesS
   const matchText = matchCount === 1 ? 'run' : 'runs';
 
   return (
-    <div className="bg-white dark:bg-gray-900 p-3 rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
-      <h3 className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wide">
+    <div className="bg-raised p-3 rounded-lg border border-border overflow-hidden">
+      <h3 className="text-xs font-medium text-muted mb-2 uppercase tracking-wide">
         Previous Efforts
       </h3>
       <div className="space-y-3">
         {/* Match count */}
-        <div className="text-sm text-gray-900 dark:text-gray-100">
+        <div className="text-sm text-ink">
           {matchCount} {matchText} on similar route
         </div>
 
@@ -166,7 +166,7 @@ export function RouteMatchesSummary({ workoutId, currentWorkout }: RouteMatchesS
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
             {highlights.map((highlight) => (
               <div key={`${highlight.type}-${highlight.route.workoutId}`} className="space-y-0.5 min-w-0">
-                <div className="text-xs font-medium text-gray-900 dark:text-gray-100 break-words">
+                <div className="text-xs font-medium text-ink break-words">
                   {highlight.label}: {formatDate(highlight.route.startedAt)}
                 </div>
                 {highlight.value && (
@@ -175,11 +175,11 @@ export function RouteMatchesSummary({ workoutId, currentWorkout }: RouteMatchesS
                       highlight.route.timeDifferenceS !== undefined &&
                       highlight.route.timeDifferenceS !== null
                         ? highlight.route.timeDifferenceS < 0
-                          ? 'text-green-600 dark:text-green-400'
+                          ? 'text-ink'
                           : highlight.route.timeDifferenceS > 0
-                          ? 'text-red-600 dark:text-red-400'
-                          : 'text-gray-500 dark:text-gray-400'
-                        : 'text-gray-500 dark:text-gray-400'
+                          ? 'text-danger'
+                          : 'text-muted'
+                        : 'text-muted'
                     }`}
                   >
                     {highlight.value}
@@ -193,7 +193,7 @@ export function RouteMatchesSummary({ workoutId, currentWorkout }: RouteMatchesS
         {/* View All Matches button */}
         <button
           onClick={handleViewAll}
-          className="w-full mt-3 px-3 py-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-md transition-colors flex items-center justify-center gap-1"
+          className="w-full mt-3 px-3 py-2 text-sm font-medium text-ink hover:bg-canvas rounded-tempo transition-colors flex items-center justify-center gap-1"
         >
           <span>View All Matches</span>
           <IconChevronRight className="w-4 h-4" />

--- a/frontend/components/ShoeManagementSection.tsx
+++ b/frontend/components/ShoeManagementSection.tsx
@@ -194,13 +194,13 @@ export function ShoeManagementSection() {
 
       {/* Default Shoe Selector */}
       <div className="mb-6">
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+        <label className="block text-sm font-medium text-ink mb-2">
           Default Shoe
         </label>
         <select
           value={defaultShoe?.defaultShoeId || ''}
           onChange={(e) => handleSetDefault(e.target.value === '' ? null : e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+          className="w-full px-3 py-2 border border-border rounded-tempo bg-canvas text-ink focus:outline-none focus:ring-2 focus:ring-volt"
         >
           <option value="">None</option>
           {shoes?.map((shoe) => (
@@ -209,7 +209,7 @@ export function ShoeManagementSection() {
             </option>
           ))}
         </select>
-        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+        <p className="text-xs text-muted mt-1">
           New workouts will automatically be assigned to the default shoe.
         </p>
       </div>
@@ -223,35 +223,35 @@ export function ShoeManagementSection() {
           + Add New Shoe
         </Button>
       ) : (
-        <div className="mb-6 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Add New Shoe</h3>
+        <div className="mb-6 p-4 bg-canvas rounded-lg border border-border">
+          <h3 className="text-sm font-semibold text-ink mb-3">Add New Shoe</h3>
           <div className="space-y-3">
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label className="block text-sm font-medium text-ink mb-1">
                 Brand *
               </label>
               <input
                 type="text"
                 value={newShoe.brand}
                 onChange={(e) => setNewShoe({ ...newShoe, brand: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+                className="w-full px-3 py-2 border border-border rounded-tempo bg-canvas text-ink focus:outline-none focus:ring-2 focus:ring-volt"
                 placeholder="e.g., Nike"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label className="block text-sm font-medium text-ink mb-1">
                 Model *
               </label>
               <input
                 type="text"
                 value={newShoe.model}
                 onChange={(e) => setNewShoe({ ...newShoe, model: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+                className="w-full px-3 py-2 border border-border rounded-tempo bg-canvas text-ink focus:outline-none focus:ring-2 focus:ring-volt"
                 placeholder="e.g., Air Zoom Pegasus 40"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label className="block text-sm font-medium text-ink mb-1">
                 Initial Mileage (optional)
               </label>
               <input
@@ -259,10 +259,10 @@ export function ShoeManagementSection() {
                 step="0.1"
                 value={newShoeInitialMileageInput}
                 onChange={(e) => setNewShoeInitialMileageInput(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+                className="w-full px-3 py-2 border border-border rounded-tempo bg-canvas text-ink focus:outline-none focus:ring-2 focus:ring-volt"
                 placeholder={unitPreference === 'imperial' ? 'Miles already on shoe' : 'Kilometers already on shoe'}
               />
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              <p className="text-xs text-muted mt-1">
                 Enter mileage in {unitPreference === 'imperial' ? 'miles' : 'kilometers'}
               </p>
             </div>
@@ -299,34 +299,34 @@ export function ShoeManagementSection() {
           shoes?.map((shoe) => (
             <div
               key={shoe.id}
-              className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
+              className="p-4 bg-canvas rounded-lg border border-border"
             >
               {editingId === shoe.id ? (
                 <div className="space-y-3">
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    <label className="block text-sm font-medium text-ink mb-1">
                       Brand *
                     </label>
                     <input
                       type="text"
                       value={editShoe.brand || ''}
                       onChange={(e) => setEditShoe({ ...editShoe, brand: e.target.value })}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+                      className="w-full px-3 py-2 border border-border rounded-tempo bg-canvas text-ink focus:outline-none focus:ring-2 focus:ring-volt"
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    <label className="block text-sm font-medium text-ink mb-1">
                       Model *
                     </label>
                     <input
                       type="text"
                       value={editShoe.model || ''}
                       onChange={(e) => setEditShoe({ ...editShoe, model: e.target.value })}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+                      className="w-full px-3 py-2 border border-border rounded-tempo bg-canvas text-ink focus:outline-none focus:ring-2 focus:ring-volt"
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    <label className="block text-sm font-medium text-ink mb-1">
                       Initial Mileage
                     </label>
                     <input
@@ -334,10 +334,10 @@ export function ShoeManagementSection() {
                       step="0.1"
                       value={editShoeInitialMileageInput}
                       onChange={(e) => setEditShoeInitialMileageInput(e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+                      className="w-full px-3 py-2 border border-border rounded-tempo bg-canvas text-ink focus:outline-none focus:ring-2 focus:ring-volt"
                       placeholder={unitPreference === 'imperial' ? 'Miles' : 'Kilometers'}
                     />
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    <p className="text-xs text-muted mt-1">
                       Enter mileage in {unitPreference === 'imperial' ? 'miles' : 'kilometers'}
                     </p>
                   </div>
@@ -357,10 +357,10 @@ export function ShoeManagementSection() {
                 <div>
                   <div className="flex items-start justify-between mb-2">
                     <div>
-                      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                      <h3 className="text-lg font-semibold text-ink">
                         {shoe.brand} {shoe.model}
                       </h3>
-                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                      <p className="text-sm text-muted">
                         Total: {shoe.totalMileage.toFixed(1)} {shoe.unit}
                       </p>
                       {defaultShoe?.defaultShoeId === shoe.id && (

--- a/frontend/components/SimilarRoutesSection.tsx
+++ b/frontend/components/SimilarRoutesSection.tsx
@@ -123,11 +123,11 @@ export function SimilarRoutesSection({ workoutId, currentWorkout }: SimilarRoute
   if (isLoading) {
     return (
       <div>
-        <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2 uppercase tracking-wide">
+        <h3 className="text-xs font-medium text-muted mb-2 uppercase tracking-wide">
           Previous Efforts
         </h3>
         <div className="flex items-center justify-center py-4">
-          <p className="text-sm text-gray-600 dark:text-gray-400">Loading...</p>
+          <p className="text-sm text-muted">Loading...</p>
         </div>
       </div>
     );
@@ -137,11 +137,11 @@ export function SimilarRoutesSection({ workoutId, currentWorkout }: SimilarRoute
   if (isError) {
     return (
       <div>
-        <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2 uppercase tracking-wide">
+        <h3 className="text-xs font-medium text-muted mb-2 uppercase tracking-wide">
           Previous Efforts
         </h3>
-        <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
-          <p className="text-sm text-red-800 dark:text-red-200">
+        <div className="p-3 bg-canvas border border-danger rounded-tempo">
+          <p className="text-sm text-danger">
             Unable to load previous efforts. Please try again.
           </p>
         </div>
@@ -153,11 +153,11 @@ export function SimilarRoutesSection({ workoutId, currentWorkout }: SimilarRoute
   if (!data || data.length === 0) {
     return (
       <div>
-        <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2 uppercase tracking-wide">
+        <h3 className="text-xs font-medium text-muted mb-2 uppercase tracking-wide">
           Previous Efforts
         </h3>
-        <div className="p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
-          <p className="text-sm text-gray-500 dark:text-gray-400">
+        <div className="p-3 bg-canvas rounded-lg border border-border">
+          <p className="text-sm text-muted">
             No previous efforts found on this route.
           </p>
         </div>
@@ -169,7 +169,7 @@ export function SimilarRoutesSection({ workoutId, currentWorkout }: SimilarRoute
   // then by date (most recent first), then by distance similarity
   return (
     <div>
-      <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2 uppercase tracking-wide">
+      <h3 className="text-xs font-medium text-muted mb-2 uppercase tracking-wide">
         Previous Efforts
       </h3>
       <div className="space-y-2">
@@ -177,29 +177,29 @@ export function SimilarRoutesSection({ workoutId, currentWorkout }: SimilarRoute
           <Link
             key={route.workoutId}
             href={`/dashboard/${route.workoutId}`}
-            className="block p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-colors"
+            className="block p-3 bg-canvas rounded-lg border border-border hover:bg-canvas hover:border-ink transition-colors"
           >
             <div className="space-y-1.5">
               {/* Date */}
-              <div className="text-xs font-medium text-gray-900 dark:text-gray-100">
+              <div className="text-xs font-medium text-ink">
                 {formatDate(route.startedAt)}
               </div>
 
               {/* Duration with time difference */}
               <div className="flex items-center justify-between">
-                <div className="text-xs text-gray-500 dark:text-gray-400">Duration</div>
+                <div className="text-xs text-muted">Duration</div>
                 <div className="flex items-center gap-1.5">
-                  <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                  <span className="text-sm font-semibold text-ink">
                     {formatDuration(route.durationS)}
                   </span>
                   {route.timeDifferenceS !== undefined && route.timeDifferenceS !== null && (
                     <span
                       className={`text-xs ${
                         route.timeDifferenceS < 0
-                          ? 'text-green-600 dark:text-green-400'
+                          ? 'text-ink'
                           : route.timeDifferenceS > 0
-                          ? 'text-red-600 dark:text-red-400'
-                          : 'text-gray-500 dark:text-gray-400'
+                          ? 'text-danger'
+                          : 'text-muted'
                       }`}
                     >
                       {formatTimeDifference(route.timeDifferenceS)}
@@ -215,19 +215,19 @@ export function SimilarRoutesSection({ workoutId, currentWorkout }: SimilarRoute
 
               {/* Pace with pace difference */}
               <div className="flex items-center justify-between">
-                <div className="text-xs text-gray-500 dark:text-gray-400">Pace</div>
+                <div className="text-xs text-muted">Pace</div>
                 <div className="flex items-center gap-1.5">
-                  <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                  <span className="text-sm font-semibold text-ink">
                     {formatPace(route.avgPaceS, unitPreference)}
                   </span>
                   {route.paceDifferenceS !== undefined && route.paceDifferenceS !== null && (
                     <span
                       className={`text-xs ${
                         route.paceDifferenceS < 0
-                          ? 'text-green-600 dark:text-green-400'
+                          ? 'text-ink'
                           : route.paceDifferenceS > 0
-                          ? 'text-red-600 dark:text-red-400'
-                          : 'text-gray-500 dark:text-gray-400'
+                          ? 'text-danger'
+                          : 'text-muted'
                       }`}
                     >
                       {formatPaceDifference(route.paceDifferenceS, unitPreference)}
@@ -243,8 +243,8 @@ export function SimilarRoutesSection({ workoutId, currentWorkout }: SimilarRoute
 
               {/* Distance */}
               <div className="flex items-center justify-between">
-                <div className="text-xs text-gray-500 dark:text-gray-400">Distance</div>
-                <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                <div className="text-xs text-muted">Distance</div>
+                <div className="text-sm font-semibold text-ink">
                   {formatDistance(route.distanceM, unitPreference)}
                 </div>
               </div>
@@ -252,9 +252,9 @@ export function SimilarRoutesSection({ workoutId, currentWorkout }: SimilarRoute
               {/* Relative Effort (if available) */}
               {route.relativeEffort !== null && route.relativeEffort !== undefined && (
                 <div className="flex items-center justify-between">
-                  <div className="text-xs text-gray-500 dark:text-gray-400">Relative Effort</div>
+                  <div className="text-xs text-muted">Relative Effort</div>
                   <div className="flex items-center gap-1.5">
-                    <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                    <span className="text-sm font-semibold text-ink">
                       {route.relativeEffort}
                     </span>
                     {currentWorkout.relativeEffort !== null &&
@@ -267,10 +267,10 @@ export function SimilarRoutesSection({ workoutId, currentWorkout }: SimilarRoute
                             <span
                               className={`text-xs ${
                                 effortDiff < 0
-                                  ? 'text-green-600 dark:text-green-400'
+                                  ? 'text-ink'
                                   : effortDiff > 0
-                                  ? 'text-red-600 dark:text-red-400'
-                                  : 'text-gray-500 dark:text-gray-400'
+                                  ? 'text-danger'
+                                  : 'text-muted'
                               }`}
                             >
                               ({sign}{absDiff})
@@ -290,9 +290,9 @@ export function SimilarRoutesSection({ workoutId, currentWorkout }: SimilarRoute
               {/* Elevation Gain (if available) */}
               {route.elevGainM !== null && route.elevGainM !== undefined && (
                 <div className="flex items-center justify-between">
-                  <div className="text-xs text-gray-500 dark:text-gray-400">Elevation</div>
+                  <div className="text-xs text-muted">Elevation</div>
                   <div className="flex items-center gap-1.5">
-                    <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                    <span className="text-sm font-semibold text-ink">
                       {formatElevation(route.elevGainM, unitPreference)}
                     </span>
                     {currentWorkout.elevGainM !== null &&
@@ -317,7 +317,7 @@ export function SimilarRoutesSection({ workoutId, currentWorkout }: SimilarRoute
                             : `${Math.round(absDiff)}m`;
                           
                           return (
-                            <span className="text-xs text-gray-500 dark:text-gray-400">
+                            <span className="text-xs text-muted">
                               ({diffFormatted} {moreLess})
                             </span>
                           );

--- a/frontend/components/TempoExportImport.tsx
+++ b/frontend/components/TempoExportImport.tsx
@@ -109,89 +109,89 @@ export function TempoExportImport() {
         )}
 
         {mutation.isError && (
-          <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
-            <p className="text-sm text-red-800 dark:text-red-200">
+          <div className="p-4 bg-canvas border border-danger rounded-tempo">
+            <p className="text-sm text-danger">
               Error: {mutation.error instanceof Error ? mutation.error.message : 'Unknown error'}
             </p>
           </div>
         )}
 
         {importResult && (
-          <div className="p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg space-y-3">
-            <h3 className="text-lg font-semibold text-green-900 dark:text-green-100">
+          <div className="p-4 bg-canvas border border-border rounded-tempo space-y-3">
+            <h3 className="text-lg font-semibold text-ink">
               {importResult.success ? 'Import Complete!' : 'Import Completed with Errors'}
             </h3>
-            <div className="text-sm text-green-800 dark:text-green-200 space-y-2">
+            <div className="text-sm text-ink space-y-2">
               <div className="grid grid-cols-2 gap-2">
                 <div>
                   <span className="font-medium">Settings:</span>{' '}
-                  <span className="text-green-700 dark:text-green-300">
+                  <span className="text-muted">
                     {importResult.statistics.settings.imported} imported
                   </span>
                   {importResult.statistics.settings.skipped > 0 && (
-                    <span className="text-yellow-700 dark:text-yellow-300 ml-1">
+                    <span className="text-muted ml-1">
                       ({importResult.statistics.settings.skipped} skipped)
                     </span>
                   )}
                 </div>
                 <div>
                   <span className="font-medium">Shoes:</span>{' '}
-                  <span className="text-green-700 dark:text-green-300">
+                  <span className="text-muted">
                     {importResult.statistics.shoes.imported} imported
                   </span>
                   {importResult.statistics.shoes.skipped > 0 && (
-                    <span className="text-yellow-700 dark:text-yellow-300 ml-1">
+                    <span className="text-muted ml-1">
                       ({importResult.statistics.shoes.skipped} skipped)
                     </span>
                   )}
                 </div>
                 <div>
                   <span className="font-medium">Workouts:</span>{' '}
-                  <span className="text-green-700 dark:text-green-300">
+                  <span className="text-muted">
                     {importResult.statistics.workouts.imported} imported
                   </span>
                   {importResult.statistics.workouts.skipped > 0 && (
-                    <span className="text-yellow-700 dark:text-yellow-300 ml-1">
+                    <span className="text-muted ml-1">
                       ({importResult.statistics.workouts.skipped} skipped)
                     </span>
                   )}
                 </div>
                 <div>
                   <span className="font-medium">Routes:</span>{' '}
-                  <span className="text-green-700 dark:text-green-300">
+                  <span className="text-muted">
                     {importResult.statistics.routes.imported} imported
                   </span>
                 </div>
                 <div>
                   <span className="font-medium">Splits:</span>{' '}
-                  <span className="text-green-700 dark:text-green-300">
+                  <span className="text-muted">
                     {importResult.statistics.splits.imported} imported
                   </span>
                 </div>
                 <div>
                   <span className="font-medium">Time Series:</span>{' '}
-                  <span className="text-green-700 dark:text-green-300">
+                  <span className="text-muted">
                     {importResult.statistics.timeSeries.imported} imported
                   </span>
                 </div>
                 <div>
                   <span className="font-medium">Media:</span>{' '}
-                  <span className="text-green-700 dark:text-green-300">
+                  <span className="text-muted">
                     {importResult.statistics.media.imported} imported
                   </span>
                   {importResult.statistics.media.skipped > 0 && (
-                    <span className="text-yellow-700 dark:text-yellow-300 ml-1">
+                    <span className="text-muted ml-1">
                       ({importResult.statistics.media.skipped} skipped)
                     </span>
                   )}
                 </div>
                 <div>
                   <span className="font-medium">Best Efforts:</span>{' '}
-                  <span className="text-green-700 dark:text-green-300">
+                  <span className="text-muted">
                     {importResult.statistics.bestEfforts.imported} imported
                   </span>
                   {importResult.statistics.bestEfforts.skipped > 0 && (
-                    <span className="text-yellow-700 dark:text-yellow-300 ml-1">
+                    <span className="text-muted ml-1">
                       ({importResult.statistics.bestEfforts.skipped} skipped)
                     </span>
                   )}
@@ -200,7 +200,7 @@ export function TempoExportImport() {
               
               {importResult.warnings && importResult.warnings.length > 0 && (
                 <details className="mt-2">
-                  <summary className="cursor-pointer text-yellow-700 dark:text-yellow-300 hover:underline">
+                  <summary className="cursor-pointer text-muted hover:underline">
                     View warnings ({importResult.warnings.length})
                   </summary>
                   <ul className="mt-2 ml-4 list-disc space-y-1">
@@ -215,7 +215,7 @@ export function TempoExportImport() {
               
               {importResult.errors && importResult.errors.length > 0 && (
                 <details className="mt-2">
-                  <summary className="cursor-pointer text-red-700 dark:text-red-300 hover:underline">
+                  <summary className="cursor-pointer text-danger hover:underline">
                     View errors ({importResult.errors.length})
                   </summary>
                   <ul className="mt-2 ml-4 list-disc space-y-1">

--- a/frontend/components/WorkoutMediaGallery.tsx
+++ b/frontend/components/WorkoutMediaGallery.tsx
@@ -46,8 +46,8 @@ export function WorkoutMediaGallery({ workoutId, media, isLoading, onMediaClick,
   if (isLoading) {
     return (
       <div className="mt-4">
-        <dt className="text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">Media</dt>
-        <dd className="text-sm text-gray-500 dark:text-gray-400">Loading media...</dd>
+        <dt className="text-sm font-medium text-muted mb-2">Media</dt>
+        <dd className="text-sm text-muted">Loading media...</dd>
       </div>
     );
   }
@@ -73,7 +73,7 @@ export function WorkoutMediaGallery({ workoutId, media, isLoading, onMediaClick,
 
   return (
     <div className="mt-4">
-      <dt className="text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">
+      <dt className="text-sm font-medium text-muted mb-2">
         Media {process.env.NODE_ENV === 'development' && `(${media.length} items)`}
       </dt>
       <dd>
@@ -81,7 +81,7 @@ export function WorkoutMediaGallery({ workoutId, media, isLoading, onMediaClick,
           {media.map((item, index) => (
             <div
               key={item.id}
-              className="relative aspect-square rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-md transition-all group"
+              className="relative aspect-square rounded-lg overflow-hidden border border-border hover:border-ink hover:shadow-md transition-all group"
             >
               <button
                 onClick={() => onMediaClick(item, index)}
@@ -95,7 +95,7 @@ export function WorkoutMediaGallery({ workoutId, media, isLoading, onMediaClick,
                   loading="lazy"
                 />
               ) : isVideo(item.mimeType) ? (
-                <div className="w-full h-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
+                <div className="w-full h-full bg-canvas flex items-center justify-center">
                   <video
                     src={getWorkoutMediaUrl(workoutId, item.id)}
                     className="w-full h-full object-cover"
@@ -106,8 +106,8 @@ export function WorkoutMediaGallery({ workoutId, media, isLoading, onMediaClick,
                   </div>
                 </div>
               ) : (
-                <div className="w-full h-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
-                  <IconFile className="w-8 h-8 text-gray-400" />
+                <div className="w-full h-full bg-canvas flex items-center justify-center">
+                  <IconFile className="w-8 h-8 text-muted" />
                 </div>
               )}
               </button>
@@ -115,7 +115,7 @@ export function WorkoutMediaGallery({ workoutId, media, isLoading, onMediaClick,
               <button
                 onClick={(e) => handleDelete(e, item.id, item.filename)}
                 disabled={deleteMutation.isPending}
-                className="absolute top-2 right-2 p-1.5 bg-red-600 hover:bg-red-700 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed z-10"
+                className="absolute top-2 right-2 p-1.5 bg-danger text-on-danger hover:opacity-90 rounded-full opacity-0 group-hover:opacity-100 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed z-10"
                 aria-label="Delete media"
                 title="Delete media"
               >


### PR DESCRIPTION
## Summary
- Dark-first command-center identity (Geist, T mark, black + volt yellow) with a hand-rolled kit (`PageShell`, `Card`, `Button`, `Dialog`, `EmptyState`, `Tabs`). System / Dark / Light lives in this browser only (`tempo-appearance` in `localStorage`).
- Control plane and Workout overview reskinned without changing IA. Workout overview now shows heart rate, pace, and elevation from `WorkoutTimeSeries`, plus a shared Highlight across splits, map, and charts.
- Maps use Carto Dark Matter in Dark and Voyager in Light. Relative Effort chart clipping and leftover gray/blue chrome are cleaned up onto identity tokens.

## Test plan
- [ ] Appearance: System / Dark / Light in Settings; reload keeps the choice; light mode does not fill chrome with volt; primary buttons are ink-on-light / volt-on-dark
- [ ] Control plane: dashboard, activities, import, settings, shoes, retired shoes, login all use kit surfaces (no navy `gray-800` inputs or default-blue radios)
- [ ] Workout overview: time-series charts when samples exist; empty state when they do not
- [ ] Shared Highlight: hover/click split, chart, or route; the other two follow; mouse leave restores the unhighlighted overview
- [ ] Maps: Dark Matter in Dark, Voyager in Light; route stroke and split highlight follow tokens
- [ ] Relative Effort graph: Y-axis labels and Sunday’s last point are fully visible