### PR TITLE
feat: first-run onboarding and import surface cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **First-run onboarding**
+  - Hard-gated wizard after registration: optional Tempo export restore, essential units/HR zones (optional default shoe), optional Strava archive
+  - `User.OnboardingCompleted` on `GET /auth/me`; `POST /auth/onboarding/complete` (idempotent); existing users backfilled completed on upgrade
 - **Import jobs** for Strava bulk and Tempo export restore
   - Command center uploads ZIPs in **512 KiB** chunks, then polls job progress; cancel and refresh resume are supported
-  - At most one active import job across Strava bulk (Import page) and Tempo restore (Settings)
+  - At most one active import job across Strava bulk and Tempo restore (onboarding or Settings → Migrate / restore)
   - Tempo export restore uses the same rails (`kind: tempo_export`) with nested statistics on the job document
 - **Command-center appearance**
   - System / Dark / Light in Settings (this browser only, `tempo-appearance` in `localStorage`; default System). Not UserSettings and not synced to iOS
@@ -19,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Shared **Highlight** across map, splits, and charts
 
 ### Changed
+- **Import page** is GPX/FIT (and `.fit.gz`) file upload only; Strava bulk and Tempo restore live under Settings → Data Management → **Migrate / restore** (also offered during onboarding)
 - **Breaking (API clients):** `POST /workouts/import/bulk` and `POST /workouts/import/export` return **202** with an import job document instead of a blocking **200** summary. Poll `GET /workouts/import/jobs/{id}` until `completed` or `failed`.
 - **Single-file import** now uses the same duplicate rule as Strava bulk: incomplete FIT/GPX JSON (or missing raw bytes) can update an existing Workout; complete duplicates are skipped. Distance, duration, and elevation are not rewritten on those updates.
 - **Strava bulk import** per-file persist uses the same Workout intake pipeline as single-file import (ZIP extract, `activities.csv`, non-run skip, and media copy unchanged).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,6 +62,10 @@ A pair of running shoes with mileage and Workout assignments.
 Single-row preferences: units, heart-rate zones, default shoe. Appearance (dark/light) is a command-center preference, not UserSettings.
 _Avoid_: config, profile
 
+**Onboarding**:
+Hard-gated first-run wizard on the command center after registration (optional Tempo export restore, essentials, optional Strava bulk). Driven by `User.OnboardingCompleted` (account flag, not UserSettings). Day-to-day Import stays GPX/FIT; late ZIPs use Settings → Migrate / restore.
+_Avoid_: setup wizard as UserSettings, re-run setup from Settings
+
 **Run type**:
 Classification of a Workout (Easy, Workout, Long Run, Race, and the same set the product already uses).
 _Avoid_: tag, category (when meaning run type)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ That's it! The database migrations run automatically on first startup. For detai
 
 ## Features
 
+- **First-run onboarding** - Guided setup after registration (optional Tempo restore, essentials, optional Strava)
 - **Multi-Format Support** - Import GPX, FIT (.fit, .fit.gz), and Strava CSV files from Garmin, Apple Watch, and other devices
 - **Workout Analytics** - Track distance, pace, elevation, splits, and time series data
 - **Workout Overview** - Map, splits, and HR/pace/elevation charts sharing one Highlight
@@ -51,7 +52,7 @@ That's it! The database migrations run automatically on first startup. For detai
 - **Interactive Maps** - Themed route maps (dark/light tiles) with tokenized polylines
 - **Media Support** - Attach photos and videos to workouts
 - **Weather Data** - Automatic weather conditions for each workout
-- **Bulk Import** - Import multiple workouts at once via ZIP file (up to 500MB)
+- **Bulk Import** - Import a Strava export ZIP as a background job (onboarding or Settings → Migrate / restore; up to 500MB)
 - **Heart Rate Zones** - Calculate zones using Age-based, Karvonen, or Custom methods
 - **Relative Effort** - Automatic calculation of workout intensity based on heart rate zones
 - **Best Efforts** - Track your fastest times for standard distances (400m to Marathon) from any segment within workouts

--- a/api/Endpoints/AuthEndpoints.cs
+++ b/api/Endpoints/AuthEndpoints.cs
@@ -259,14 +259,45 @@ public static class AuthEndpoints
             return Results.Unauthorized();
         }
 
-        return Results.Ok(new
-        {
-            userId = dbUser.Id,
-            username = dbUser.Username,
-            createdAt = dbUser.CreatedAt,
-            lastLoginAt = dbUser.LastLoginAt
-        });
+        return Results.Ok(ToCurrentUserResponse(dbUser));
     }
+
+    /// <summary>
+    /// Mark first-run onboarding as complete (idempotent).
+    /// </summary>
+    private static async Task<IResult> CompleteOnboarding(
+        ClaimsPrincipal user,
+        TempoDbContext db)
+    {
+        var userId = GetUserIdFromClaims(user);
+        if (userId == null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var dbUser = await db.Users.FindAsync(userId.Value);
+        if (dbUser == null)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (!dbUser.OnboardingCompleted)
+        {
+            dbUser.OnboardingCompleted = true;
+            await db.SaveChangesAsync();
+        }
+
+        return Results.Ok(ToCurrentUserResponse(dbUser));
+    }
+
+    private static object ToCurrentUserResponse(User dbUser) => new
+    {
+        userId = dbUser.Id,
+        username = dbUser.Username,
+        createdAt = dbUser.CreatedAt,
+        lastLoginAt = dbUser.LastLoginAt,
+        onboardingCompleted = dbUser.OnboardingCompleted
+    };
 
     /// <summary>
     /// Logout (clear auth cookie)
@@ -429,6 +460,15 @@ public static class AuthEndpoints
             .WithSummary("Get current user")
             .WithDescription(
                 "Returns information about the currently authenticated user. Accepts JWT (cookie or Bearer) or API key (Bearer, prefix tmp_).");
+
+        group.MapPost("/onboarding/complete", CompleteOnboarding)
+            .WithName("CompleteOnboarding")
+            .RequireAuthorization()
+            .Produces(200)
+            .Produces(401)
+            .WithSummary("Complete onboarding")
+            .WithDescription(
+                "Marks first-run onboarding as complete for the current user. Idempotent; cannot set the flag back to false.");
 
         group.MapPost("/logout", Logout)
             .WithName("Logout")

--- a/api/Migrations/20260816205651_AddUserOnboardingCompleted.Designer.cs
+++ b/api/Migrations/20260816205651_AddUserOnboardingCompleted.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tempo.Api.Data;
@@ -11,9 +12,11 @@ using Tempo.Api.Data;
 namespace Tempo.Api.Migrations
 {
     [DbContext(typeof(TempoDbContext))]
-    partial class TempoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260816205651_AddUserOnboardingCompleted")]
+    partial class AddUserOnboardingCompleted
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20260816205651_AddUserOnboardingCompleted.cs
+++ b/api/Migrations/20260816205651_AddUserOnboardingCompleted.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tempo.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserOnboardingCompleted : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "OnboardingCompleted",
+                table: "Users",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OnboardingCompleted",
+                table: "Users");
+        }
+    }
+}

--- a/api/Models/User.cs
+++ b/api/Models/User.cs
@@ -23,6 +23,12 @@ public class User
     /// </summary>
     public int SessionVersion { get; set; }
 
+    /// <summary>
+    /// True after first-run onboarding finishes. New registrations default to false;
+    /// existing users are backfilled to true by migration.
+    /// </summary>
+    public bool OnboardingCompleted { get; set; }
+
     public ICollection<ApiKey> ApiKeys { get; set; } = new List<ApiKey>();
 }
 

--- a/api/Services/DatabaseMigrationHelper.cs
+++ b/api/Services/DatabaseMigrationHelper.cs
@@ -48,6 +48,7 @@ public static class DatabaseMigrationHelper
         { ("UserSettings", "DefaultShoeId"), "20251201120000_AddShoeTracking" },
         { ("Shoes", "IsRetired"), "20260429231609_AddShoeIsRetired" },
         { ("Users", "SessionVersion"), "20260510120000_AddUserSessionVersion" },
+        { ("Users", "OnboardingCompleted"), "20260816205651_AddUserOnboardingCompleted" },
         // AddRpeToWorkout migration
         { ("Workouts", "Rpe"), "20260511200212_AddRpeToWorkout" },
         { ("ImportJobs", "CancelRequested"), "20260816182633_AddImportJobCancelAndChunks" },

--- a/api/Tempo.Api.Tests/IntegrationTests/AuthEndpointsTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/AuthEndpointsTests.cs
@@ -573,6 +573,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         result!.UserId.Should().NotBeEmpty();
         result.Username.Should().Be("testuser");
         result.CreatedAt.Should().BeBefore(DateTime.UtcNow);
+        result.OnboardingCompleted.Should().BeFalse();
     }
 
     [Fact]
@@ -636,6 +637,79 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    #endregion
+
+    #region Onboarding complete
+
+    [Fact]
+    public async Task Register_NewUser_HasOnboardingCompletedFalse()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "newop", TestPasswords.Default);
+
+        var me = await client.GetAsync("/auth/me");
+        me.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await me.Content.ReadFromJsonAsync<CurrentUserResponse>();
+        body.Should().NotBeNull();
+        body!.OnboardingCompleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CompleteOnboarding_WhenUnauthenticated_ReturnsUnauthorized()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsync("/auth/onboarding/complete", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task CompleteOnboarding_SetsFlagTrue_AndIsIdempotent()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "setupuser", TestPasswords.Default);
+
+        var first = await client.PostAsync("/auth/onboarding/complete", null);
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        var firstBody = await first.Content.ReadFromJsonAsync<CurrentUserResponse>();
+        firstBody.Should().NotBeNull();
+        firstBody!.OnboardingCompleted.Should().BeTrue();
+
+        var second = await client.PostAsync("/auth/onboarding/complete", null);
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        var secondBody = await second.Content.ReadFromJsonAsync<CurrentUserResponse>();
+        secondBody.Should().NotBeNull();
+        secondBody!.OnboardingCompleted.Should().BeTrue();
+
+        var me = await client.GetAsync("/auth/me");
+        me.StatusCode.Should().Be(HttpStatusCode.OK);
+        var meBody = await me.Content.ReadFromJsonAsync<CurrentUserResponse>();
+        meBody!.OnboardingCompleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetCurrentUser_WhenOnboardingCompletedInDb_ReturnsTrue()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory, "backfilled", TestPasswords.Default);
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            var user = await db.Users.FirstAsync(u => u.Username == "backfilled");
+            user.OnboardingCompleted = true;
+            await db.SaveChangesAsync();
+        }
+
+        var me = await client.GetAsync("/auth/me");
+        me.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await me.Content.ReadFromJsonAsync<CurrentUserResponse>();
+        body.Should().NotBeNull();
+        body!.OnboardingCompleted.Should().BeTrue();
     }
 
     #endregion
@@ -864,6 +938,7 @@ public class AuthEndpointsTests : IClassFixture<TempoWebApplicationFactory>
         public string Username { get; set; } = string.Empty;
         public DateTime CreatedAt { get; set; }
         public DateTime? LastLoginAt { get; set; }
+        public bool OnboardingCompleted { get; set; }
     }
 
     private class LogoutResponse

--- a/api/bruno/Tempo.Api/Authentication/Complete onboarding.bru
+++ b/api/bruno/Tempo.Api/Authentication/Complete onboarding.bru
@@ -1,0 +1,65 @@
+meta {
+  name: Complete onboarding
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/auth/onboarding/complete
+  body: none
+  auth: inherit
+}
+
+docs {
+  Mark first-run onboarding complete for the current user (idempotent). Requires authentication.
+}
+
+example {
+  name: 200 Response
+  description: OK
+  
+  request: {
+    url: {{baseUrl}}/auth/onboarding/complete
+    method: POST
+    mode: none
+  }
+  
+  response: {
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}
+
+example {
+  name: 401 Response
+  description: Unauthorized
+  
+  request: {
+    url: {{baseUrl}}/auth/onboarding/complete
+    method: POST
+    mode: none
+  }
+  
+  response: {
+    status: {
+      code: 401
+      text: Unauthorized
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/docs/deployment/backup-restore.md
+++ b/docs/deployment/backup-restore.md
@@ -27,7 +27,7 @@ Tempo's export feature provides a user-friendly way to backup your data directly
 
 1. Log into Tempo
 2. Navigate to Settings
-3. Find the "Export / Import" section
+3. Find the **Export** section under Data Management
 4. Click "Export All Data"
 5. Wait for the download to complete
 
@@ -148,12 +148,12 @@ Tempo's import feature provides a user-friendly way to restore data from an expo
 
 1. Log into Tempo
 2. Navigate to Settings
-3. Find the "Export / Import" section
-4. In the "Import Data" area, click or drag and drop your export ZIP file
+3. Under Data Management, expand **Migrate / restore**
+4. In **Restore Tempo export**, click or drag and drop your export ZIP file
 5. Watch upload progress, then restore progress (`processed` / `total`)
 6. When finished, review the import summary
 
-You can cancel while uploading or restoring; data already restored stays. At most one import job runs at a time across Settings restore and Strava bulk import on the Import page. See [Settings export/import](../user-guide/settings.md#export--import) for details.
+You can cancel while uploading or restoring; data already restored stays. At most one import job runs at a time across Tempo restore and Strava bulk import (both under Migrate / restore). See [Settings export/import](../user-guide/settings.md#export--import) for details.
 
 The import will:
 - Restore all workouts, media, shoes, and settings

--- a/docs/deployment/backup-restore.md
+++ b/docs/deployment/backup-restore.md
@@ -146,6 +146,8 @@ Tempo's import feature provides a user-friendly way to restore data from an expo
 
 #### Using the Import Feature
 
+On a **fresh install**, you can restore a Tempo export during [first-run onboarding](../getting-started/onboarding.md). After setup (or on an existing instance):
+
 1. Log into Tempo
 2. Navigate to Settings
 3. Under Data Management, expand **Migrate / restore**

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -235,7 +235,7 @@ These limits are already configured in the API (`Program.cs`) for Kestrel and fo
 
 After configuration, smoke-test through the command center (`:3000`):
 1. Export a large archive from Strava (typically 50–200MB), or use a Tempo Settings export with media
-2. Strava: **Import** page → Bulk Import Strava Export; Tempo restore: **Settings** → Export / Import
+2. Strava or Tempo restore: **Settings** → Data Management → **Migrate / restore** (or first-run onboarding)
 3. Confirm upload progress then import/restore progress; optional: retry with Bruno/curl against the API for the whole-ZIP adapter
 
 ## SSL/TLS Configuration

--- a/docs/developers/api-reference.md
+++ b/docs/developers/api-reference.md
@@ -114,6 +114,19 @@ GET /auth/me
 
 Requires authentication via JWT (cookie or Bearer) **or** a valid API key (`Authorization: Bearer tmp_…`).
 
+Response includes:
+
+- `userId`, `username`, `createdAt`, `lastLoginAt`
+- `onboardingCompleted` (boolean) — `false` for new registrations until first-run setup finishes; existing users are backfilled `true` by migration
+
+### Complete Onboarding
+
+```http
+POST /auth/onboarding/complete
+```
+
+Requires authentication. Marks first-run onboarding complete for the current user (`onboardingCompleted: true`). Idempotent; there is no API to set the flag back to `false`. Returns the same current-user payload as `GET /auth/me`.
+
 ### Logout
 
 ```http
@@ -147,7 +160,7 @@ Outcomes per file: `created`, `updated`, or `skipped` (plus error). Incomplete F
 
 ### Bulk Import
 
-Command-center Import uploads a Strava ZIP in **512 KiB** chunks, then polls the job. Bruno/curl can still POST the whole ZIP.
+The command center uploads a Strava ZIP in **512 KiB** chunks during [first-run onboarding](../getting-started/onboarding.md) or **Settings → Migrate / restore** (not the day-to-day Import page). Bruno/curl can still POST the whole ZIP.
 
 ```http
 POST /workouts/import/jobs

--- a/docs/developers/architecture.md
+++ b/docs/developers/architecture.md
@@ -141,6 +141,7 @@ This ensures migrations can be safely applied even when database state doesn't m
 - Registration only available when no users exist (single-user deployment)
 - Password hashing using BCrypt
 - All workout and settings endpoints require authentication (except `/health` and `/version`)
+- **First-run onboarding**: `User.OnboardingCompleted` (new registrations `false`; migration backfills existing users `true`). `GET /auth/me` exposes `onboardingCompleted`; `POST /auth/onboarding/complete` sets it `true` only (idempotent). The command center hard-gates app routes to `/onboarding` until complete.
 
 ## Database Indexing
 
@@ -153,13 +154,15 @@ The `TempoDbContext` configures several important indexes:
 
 ## Key File Locations
 
-- **API Endpoints**: `api/Endpoints/*.cs`
-- **Models**: `api/Models/*.cs`
+- **API Endpoints**: `api/Endpoints/*.cs` — auth/onboarding in `api/Endpoints/AuthEndpoints.cs`
+- **Models**: `api/Models/*.cs` (`User.OnboardingCompleted`)
 - **Workout intake / geometry**: `api/Services/WorkoutIntake.cs`, `api/Services/TrackGeometry.cs`, `api/Services/TrackPointRehydration.cs`
 - **Import jobs**: `api/Services/ImportJobService.cs`, `api/Services/ImportJobWorker.cs`, `api/Services/StravaBulkImportOrchestrator.cs`, `api/Services/BulkImportService.cs`, `api/Services/ImportService.cs`
 - **Services**: `api/Services/*.cs`
 - **Database Context**: `api/Data/TempoDbContext.cs`
-- **Frontend API Client**: `frontend/lib/api.ts` (includes `getWorkoutTimeSeries`)
+- **Frontend API Client**: `frontend/lib/api.ts` (includes `getWorkoutTimeSeries`, `completeOnboarding`)
+- **Auth gate**: `frontend/components/AuthGuard.tsx`, `frontend/contexts/AuthContext.tsx`
+- **Onboarding**: `frontend/app/onboarding/page.tsx`, `frontend/components/onboarding/`
 - **Appearance**: `frontend/lib/appearance.ts`
 - **Highlight**: `frontend/lib/workoutHighlight.ts`
 - **Frontend Pages**: `frontend/app/*/page.tsx` — Workout overview composer is `frontend/app/dashboard/[id]/page.tsx`

--- a/docs/developers/database.md
+++ b/docs/developers/database.md
@@ -115,6 +115,7 @@ User accounts for authentication.
 - `Username` (string, unique)
 - `PasswordHash` (string) - BCrypt hashed password
 - `CreatedAt` (DateTime)
+- `OnboardingCompleted` (bool) - `true` after first-run onboarding finishes. New registrations default to `false`. The EF migration that adds this column backfills existing user rows to `true` so upgrades are not forced through the wizard.
 
 **Indexes:**
 - Unique index on `Username`

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -12,6 +12,7 @@ Tempo is a self-hostable running tracker that runs entirely on your own infrastr
 - Quick start with Docker Compose (recommended for most users)
 - Alternative installation methods
 - Initial configuration and setup
+- First-run [onboarding](onboarding.md) (restore, essentials, optional Strava)
 - Verification steps to confirm successful installation
 
 ## Installation Methods
@@ -21,13 +22,14 @@ Tempo can be installed in several ways:
 1. **[Quick Start with Docker Compose](quick-start.md)** - The fastest way to get started (recommended)
 2. **[Manual Installation](installation.md)** - Step-by-step installation for different deployment scenarios
 3. **[Configuration Guide](configuration.md)** - Configure Tempo for your environment
+4. **[First-run onboarding](onboarding.md)** - Guided setup after registration
 
 ## Next Steps
 
 1. Choose your installation method
 2. Follow the installation guide
 3. Configure Tempo for your environment
-4. Start importing your workouts!
+4. Complete [onboarding](onboarding.md), then import workouts
 
 ## Need Help?
 

--- a/docs/getting-started/onboarding.md
+++ b/docs/getting-started/onboarding.md
@@ -1,0 +1,58 @@
+# First-run onboarding
+
+After you register (or log in with an incomplete account), Tempo runs a hard-gated setup wizard. You cannot open Dashboard, Activities, Import, or Settings until onboarding finishes.
+
+## What to expect
+
+- A minimal shell (brand + steps). Logout remains available; the main navbar does not.
+- Completion is stored on your account (`onboardingCompleted`), so another browser or device does not reopen setup.
+- There is no “run setup again” entry after you finish. Ongoing configuration lives in [Settings](../user-guide/settings.md).
+
+## Setup flow
+
+### 1. Restore from a Tempo export?
+
+**Yes** — upload a Tempo export ZIP (same chunked import job as Settings restore).
+
+- Job **completed** and the export included settings → onboarding completes and you land on the dashboard.
+- Job **completed** without settings → continue to essentials (do not skip units and heart rate zones).
+- Job **failed** or **cancelled** — stay on the restore step: **Retry**, or **Set up fresh instead** (goes to essentials without marking onboarding complete).
+
+**No** — continue to essentials.
+
+### 2. Essential settings
+
+Required before you can continue:
+
+- Unit preference (metric or imperial) — affects split distances on import
+- Heart rate zones (Age-based, Karvonen, or Custom) — so relative effort can be calculated on intake
+
+Optional: collapsed **Add a default shoe** (create a shoe and set it as default). Appearance is not part of onboarding; change it later in Settings on this browser.
+
+### 3. Import a Strava archive?
+
+**No** — finish setup and go to the dashboard (empty but correctly configured).
+
+**Yes** — upload a Strava export ZIP (`activities.csv` + `activities/`). Progress, cancel, and one-active-job rules match [Bulk Import](../user-guide/bulk-import.md).
+
+- Job **completed** → onboarding completes → dashboard.
+- Job **failed** or **cancelled** — **Retry**, or **Skip for now** (completes onboarding so you can use the app).
+
+## After onboarding
+
+| Task | Where |
+|------|--------|
+| Day-to-day GPX / FIT / `.fit.gz` files | [Import](../user-guide/importing-workouts.md) |
+| Late Strava archive or Tempo export restore | Settings → Data Management → **Migrate / restore** |
+| Routine Tempo backup ZIP | Settings → **Export** |
+| Units, heart rate zones, shoes | [Settings](../user-guide/settings.md) |
+
+## Upgrades
+
+When Tempo adds onboarding, existing accounts are backfilled as already completed. Upgrading does not force you through the wizard.
+
+## Next steps
+
+- [Import workouts](../user-guide/importing-workouts.md)
+- [Bulk import from Strava](../user-guide/bulk-import.md)
+- [Backup and restore](../deployment/backup-restore.md)

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -44,7 +44,8 @@ Once all services are running, access Tempo at:
 3. Register your account (only available when no users exist)
    - Choose a username and a passphrase (**16–64** characters; see [Security](../deployment/security.md#password-requirements) for full rules)
    - Confirm your password
-   - After registration, you'll be automatically logged in
+   - After registration, you'll be automatically logged in and guided through **onboarding** (optional Tempo restore, essential settings, optional Strava archive)
+4. When setup finishes, use the Import page for day-to-day GPX/FIT files
 
 **Note:** Registration is automatically locked after the first user is created. This is a security feature for single-user deployments.
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -44,10 +44,10 @@ Once all services are running, access Tempo at:
 3. Register your account (only available when no users exist)
    - Choose a username and a passphrase (**16–64** characters; see [Security](../deployment/security.md#password-requirements) for full rules)
    - Confirm your password
-   - After registration, you'll be automatically logged in and guided through **onboarding** (optional Tempo restore, essential settings, optional Strava archive)
+   - After registration, you'll be automatically logged in and guided through **[onboarding](onboarding.md)** (optional Tempo restore, essential settings, optional Strava archive)
 4. When setup finishes, use the Import page for day-to-day GPX/FIT files
 
-**Note:** Registration is automatically locked after the first user is created. This is a security feature for single-user deployments.
+**Note:** Registration is automatically locked after the first user is created. This is a security feature for single-user deployments. See [First-run onboarding](onboarding.md) for the full setup flow.
 
 ## Verification
 
@@ -81,6 +81,7 @@ docker-compose down -v
 
 ## Next Steps
 
+- [First-run onboarding](onboarding.md)
 - [Configure Tempo](configuration.md) for your environment
 - [Import your first workout](../user-guide/importing-workouts.md)
 - Learn about [production deployment](../deployment/production.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ Tempo is a self-hostable running tracker that gives you complete control over yo
 - **Media Support** - Attach photos and videos to workouts
 - **Weather Data** - Automatic weather conditions for each workout
 - **Bulk Import** - Import a Strava export ZIP as a background job (onboarding or Settings → Migrate / restore; up to 500MB)
+- **First-run onboarding** - Guided setup after registration (optional Tempo restore, essentials, optional Strava)
 - **Data Export** - Export all your data in a portable ZIP format for backup and migration
 - **Data Import** - Restore a Tempo export as a background job under Settings → Migrate / restore with progress and cancel
 - **Heart Rate Zones** - Calculate zones using Age-based, Karvonen, or Custom methods

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,9 +21,9 @@ Tempo is a self-hostable running tracker that gives you complete control over yo
 - **Interactive Maps** - Themed route maps (dark/light tiles) with tokenized polylines
 - **Media Support** - Attach photos and videos to workouts
 - **Weather Data** - Automatic weather conditions for each workout
-- **Bulk Import** - Import a Strava export ZIP as a background job with upload/import progress (up to 500MB)
+- **Bulk Import** - Import a Strava export ZIP as a background job (onboarding or Settings → Migrate / restore; up to 500MB)
 - **Data Export** - Export all your data in a portable ZIP format for backup and migration
-- **Data Import** - Restore a Tempo export as a background job (same rails as bulk import) with progress and cancel
+- **Data Import** - Restore a Tempo export as a background job under Settings → Migrate / restore with progress and cancel
 - **Heart Rate Zones** - Calculate zones using Age-based, Karvonen, or Custom methods
 - **Relative Effort** - Automatic calculation of workout intensity based on heart rate zones
 - **Best Efforts** - Track your fastest times for standard distances (400m to Marathon) from any segment within workouts

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -121,6 +121,29 @@
         ]
       }
     },
+    "/auth/onboarding/complete": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Mark first-run onboarding as complete (idempotent).",
+        "description": "Marks first-run onboarding as complete for the current user. Idempotent; cannot set the flag back to false.",
+        "operationId": "CompleteOnboarding",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [ ]
+          }
+        ]
+      }
+    },
     "/auth/logout": {
       "post": {
         "tags": [

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -184,6 +184,7 @@ Detailed solutions for common Tempo problems.
 - Can't log in
 - Session expires immediately
 - Registration fails
+- Redirected to onboarding / cannot open Dashboard or Settings
 
 **Solutions:**
 1. Verify JWT secret key is configured (production)
@@ -191,6 +192,8 @@ Detailed solutions for common Tempo problems.
 3. Clear browser cookies
 4. Verify database has user table
 5. Check API logs for authentication errors
+6. If you are on first-run setup: complete [onboarding](../getting-started/onboarding.md) (or **Skip for now** after a failed Strava import). Existing upgraded accounts should already be marked complete and not see the wizard
+7. Late Strava or Tempo ZIP migrates live under Settings → Migrate / restore, not the Import page
 
 ### CORS Errors
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -115,9 +115,9 @@ Detailed solutions for common Tempo problems.
 3. Verify CSV references correct file paths
 4. Only "Run" activities are imported
 5. Duplicates are automatically skipped
-6. Watch upload progress, then `processed` / `total`; refresh the Import page to resume an in-progress Strava job
+6. Watch upload progress, then `processed` / `total`; refresh Settings → Migrate / restore to resume an in-progress Strava job
 7. Cancel keeps workouts already imported; re-upload the same ZIP to continue (duplicates skip)
-8. If Settings is running a Tempo restore, finish or cancel that job first (only one import job at a time)
+8. If a Tempo restore is running, finish or cancel that job first (only one import job at a time)
 
 ## Performance Issues
 

--- a/docs/troubleshooting/faq.md
+++ b/docs/troubleshooting/faq.md
@@ -51,8 +51,8 @@ Tempo supports:
 ### Can I import from Strava?
 
 Yes! You can:
-- Import individual GPX files from Strava
-- Bulk import your entire Strava history using a Strava data export
+- Import individual GPX files from Strava on the Import page
+- Bulk import your entire Strava history using a Strava data export (first-run onboarding, or Settings → Migrate / restore)
 
 ### Does Tempo sync with my devices?
 
@@ -60,7 +60,7 @@ Tempo doesn't automatically sync with devices. You need to export files from you
 
 ### Can I export my data from Tempo?
 
-Yes. Use **Settings → Export / Import** to download a ZIP of workouts, routes, splits, time series, media, shoes, settings, and best efforts, or to restore a previous export. See the [Settings export/import](../user-guide/settings.md#export--import) guide and [Backup and Restore](../deployment/backup-restore.md). You can also access PostgreSQL and the `media/` directory directly.
+Yes. Use **Settings → Export** to download a ZIP of workouts, routes, splits, time series, media, shoes, settings, and best efforts. Restore a previous export under **Settings → Migrate / restore**. See the [Settings export/import](../user-guide/settings.md#export--import) guide and [Backup and Restore](../deployment/backup-restore.md). You can also access PostgreSQL and the `media/` directory directly.
 
 ### Does Tempo work offline?
 

--- a/docs/troubleshooting/faq.md
+++ b/docs/troubleshooting/faq.md
@@ -51,8 +51,20 @@ Tempo supports:
 ### Can I import from Strava?
 
 Yes! You can:
-- Import individual GPX files from Strava on the Import page
-- Bulk import your entire Strava history using a Strava data export (first-run onboarding, or Settings → Migrate / restore)
+- Import individual GPX files from Strava on the Import page (file upload only)
+- Bulk import your entire Strava history using a Strava data export ([first-run onboarding](../getting-started/onboarding.md), or Settings → Migrate / restore)
+
+### What is first-run onboarding?
+
+After registration, Tempo guides you through optional Tempo restore, essential settings (units and heart rate zones), and an optional Strava archive. App routes stay gated until setup finishes. See [First-run onboarding](../getting-started/onboarding.md).
+
+### Will upgrading force me through onboarding again?
+
+No. Existing accounts are backfilled as already completed when onboarding ships. There is no “run setup again” entry in Settings.
+
+### I skipped Strava during onboarding. Can I import a Strava ZIP later?
+
+Yes. Open **Settings → Data Management → Migrate / restore → Import Strava archive**. Day-to-day GPX/FIT files stay on the Import page.
 
 ### Does Tempo sync with my devices?
 
@@ -121,6 +133,10 @@ See the [Contributing Guide](../developers/contributing.md) for details.
 ### Why can't I register?
 
 Registration is only available when no users exist. After the first user is created, registration is locked for security.
+
+### Why am I stuck on the setup / onboarding screen?
+
+Until onboarding completes, every app route redirects to the wizard. Finish restore or essentials (and answer the Strava question), or use **Skip for now** after a failed Strava job. Logout is available from the onboarding shell. See [First-run onboarding](../getting-started/onboarding.md).
 
 ### Why is my import slow?
 

--- a/docs/user-guide/bulk-import.md
+++ b/docs/user-guide/bulk-import.md
@@ -7,7 +7,9 @@ Import your entire Strava history at once using a Strava data export ZIP file.
 The bulk import feature allows you to import multiple workouts from a Strava data export. This is useful when:
 - Migrating from Strava to Tempo
 - Importing your complete workout history
-- Backing up and restoring workouts
+- Catching up after you skipped Strava during first-run onboarding
+
+First-run Strava import is also offered during **onboarding**. After setup, use **Settings → Migrate / restore**. Day-to-day GPX/FIT files stay on the [Import](importing-workouts.md) page.
 
 ## Requesting Your Strava Data Export
 
@@ -50,8 +52,9 @@ If your Strava export doesn't match the required structure:
 ### Step 2: Access Bulk Import
 
 1. Log in to Tempo
-2. Navigate to the Import page
-3. Find the "Bulk Import Strava Export" section
+2. Navigate to **Settings**
+3. Under **Data Management**, expand **Migrate / restore**
+4. Find **Import Strava archive**
 
 ### Step 3: Upload ZIP File
 
@@ -66,13 +69,13 @@ Bulk import processing may take several minutes depending on:
 - File sizes
 - Server performance
 
-You'll see upload progress, then import progress (`processed` / `total`). You can cancel while the job is active; workouts already imported stay. Refreshing the Import page resumes an in-progress Strava job.
+You'll see upload progress, then import progress (`processed` / `total`). You can cancel while the job is active; workouts already imported stay. Refreshing Settings resumes an in-progress Strava job under Migrate / restore.
 
 **Note**: If you've set a default shoe in Settings, all imported workouts will automatically be assigned to that shoe. You can change or remove shoe assignments later from each Workout's overview.
 
 ### One import at a time
 
-Tempo runs at most one import job at a time across Strava bulk import and [Tempo export restore in Settings](settings.md#importing-data). If a Tempo restore is already running, the Import page shows a message and will not start a Strava import until that job finishes or is cancelled in Settings. Tempo backups use Settings export/import — not this Strava bulk flow.
+Tempo runs at most one import job at a time across Strava bulk import and [Tempo export restore](settings.md#migrate--restore). If a Tempo restore is already running, Migrate / restore shows a message and will not start a Strava import until that job finishes or is cancelled. Tempo backups use Settings export — not this Strava bulk flow.
 
 ### Step 5: Review Import Summary
 
@@ -132,8 +135,8 @@ If processing seems stuck:
 
 ### Cannot Start / Message About Tempo Restore
 
-- Finish or cancel the Tempo export restore in [Settings](settings.md#importing-data) first
-- Only one import job can run at a time (Strava bulk or Settings restore)
+- Finish or cancel the Tempo export restore in [Settings → Migrate / restore](settings.md#migrate--restore) first
+- Only one import job can run at a time (Strava bulk or Tempo restore)
 
 ### Partial Import After Cancel
 
@@ -145,4 +148,3 @@ If processing seems stuck:
 - [View your imported workouts](viewing-workouts.md)
 - [Configure settings](settings.md) for your preferences (including Tempo backup restore)
 - [Add media](media.md) to enhance your workouts
-

--- a/docs/user-guide/bulk-import.md
+++ b/docs/user-guide/bulk-import.md
@@ -51,6 +51,10 @@ If your Strava export doesn't match the required structure:
 
 ### Step 2: Access Bulk Import
 
+During **[first-run onboarding](../getting-started/onboarding.md)**, choose Strava import after essentials.
+
+After setup:
+
 1. Log in to Tempo
 2. Navigate to **Settings**
 3. Under **Data Management**, expand **Migrate / restore**

--- a/docs/user-guide/importing-workouts.md
+++ b/docs/user-guide/importing-workouts.md
@@ -1,6 +1,6 @@
 # Importing Workouts
 
-Learn how to import individual workout files into Tempo.
+Learn how to import individual workout files into Tempo. For a full Strava archive ZIP, see [Bulk Import](bulk-import.md) (Settings → Migrate / restore, or first-run onboarding).
 
 ## Supported File Formats
 
@@ -8,7 +8,6 @@ Tempo supports the following workout file formats:
 
 - **GPX** (`.gpx`) - GPS Exchange Format, commonly used by Garmin, Strava, and other services
 - **FIT** (`.fit`, `.fit.gz`) - Garmin's native format, supports compressed files
-- **CSV** (`.csv`) - Strava export format with activity metadata
 
 ## How to Export from Different Devices
 
@@ -32,6 +31,8 @@ Tempo supports the following workout file formats:
 2. Click the three-dot menu (⋮)
 3. Select "Export GPX"
 4. Download the GPX file
+
+For your full Strava history as a ZIP, use [Bulk Import](bulk-import.md).
 
 ## Import Process
 

--- a/docs/user-guide/importing-workouts.md
+++ b/docs/user-guide/importing-workouts.md
@@ -1,6 +1,6 @@
 # Importing Workouts
 
-Learn how to import individual workout files into Tempo. For a full Strava archive ZIP, see [Bulk Import](bulk-import.md) (Settings → Migrate / restore, or first-run onboarding).
+Learn how to import individual GPX and FIT workout files into Tempo. The Import page is **file-only** — it does not accept Strava or Tempo ZIP archives. For a full Strava archive ZIP, see [Bulk Import](bulk-import.md) (Settings → Migrate / restore, or [first-run onboarding](../getting-started/onboarding.md)).
 
 ## Supported File Formats
 
@@ -38,8 +38,8 @@ For your full Strava history as a ZIP, use [Bulk Import](bulk-import.md).
 
 ### Step 1: Access the Import Page
 
-1. Log in to Tempo
-2. Navigate to the Import page (usually accessible from the main navigation)
+1. Log in to Tempo (and finish [onboarding](../getting-started/onboarding.md) if prompted)
+2. Navigate to the Import page from the main navigation (GPX/FIT uploads only)
 
 ### Step 2: Upload Your File
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -8,20 +8,21 @@ Tempo is a self-hosted running tracker that helps you track and analyze your wor
 
 ## Topics Covered
 
-- **[Importing Workouts](importing-workouts.md)** - Learn how to import single workout files (GPX, FIT, CSV)
-- **[Bulk Import](bulk-import.md)** - Import your entire Strava history at once
+- **[Importing Workouts](importing-workouts.md)** - Import single GPX/FIT workout files
+- **[Bulk Import](bulk-import.md)** - Import your entire Strava history (Settings → Migrate / restore, or onboarding)
 - **[Viewing Workouts](viewing-workouts.md)** - Explore the dashboard, activities list, and Workout overview
 - **[Media](media.md)** - Add photos and videos to your workouts
 - **[Analytics](analytics.md)** - Understand metrics, statistics, and performance data
-- **[Settings](settings.md)** - Configure preferences, heart rate zones, unit preferences, shoe tracking, and export/import data (including backup restoration)
+- **[Settings](settings.md)** - Configure preferences, heart rate zones, unit preferences, shoe tracking, export, and migrate/restore
 
 ## Getting Started
 
 If you're new to Tempo, start with:
 
-1. [Importing your first workout](importing-workouts.md)
-2. [Exploring the dashboard](viewing-workouts.md)
-3. [Configuring your settings](settings.md)
+1. Complete first-run onboarding (restore a Tempo export, or set essentials and optionally import Strava)
+2. [Importing your first workout](importing-workouts.md) (GPX/FIT on the Import page)
+3. [Exploring the dashboard](viewing-workouts.md)
+4. [Configuring your settings](settings.md)
 
 ## Common Workflows
 
@@ -35,17 +36,18 @@ If you're new to Tempo, start with:
 ### Bulk Import from Strava
 
 1. Request your Strava data export
-2. Upload the ZIP file via the Bulk Import feature
-3. Wait for processing to complete
-4. Review imported workouts
+2. During onboarding, choose Strava import — or later open Settings → Migrate / restore → Import Strava archive
+3. Upload the ZIP file
+4. Wait for processing to complete
+5. Review imported workouts
 
 ### Backup and Restore
 
-1. Navigate to Settings → Export / Import
+1. Navigate to Settings → Export
 2. Click "Export All Data" to create a backup
 3. Store the ZIP file safely
-4. To restore, use "Import Data" and upload the export file — watch upload then restore progress (you can cancel; already restored data stays)
-5. Only one import runs at a time (Settings restore or Strava bulk on Import); then review the import summary
+4. To restore, expand Migrate / restore → Restore Tempo export and upload the export file — watch upload then restore progress (you can cancel; already restored data stays)
+5. Only one import runs at a time (Tempo restore or Strava bulk); then review the import summary
 
 ### Analyzing Performance
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -19,7 +19,7 @@ Tempo is a self-hosted running tracker that helps you track and analyze your wor
 
 If you're new to Tempo, start with:
 
-1. Complete first-run onboarding (restore a Tempo export, or set essentials and optionally import Strava)
+1. Complete [first-run onboarding](../getting-started/onboarding.md) (restore a Tempo export, or set essentials and optionally import Strava)
 2. [Importing your first workout](importing-workouts.md) (GPX/FIT on the Import page)
 3. [Exploring the dashboard](viewing-workouts.md)
 4. [Configuring your settings](settings.md)
@@ -36,7 +36,7 @@ If you're new to Tempo, start with:
 ### Bulk Import from Strava
 
 1. Request your Strava data export
-2. During onboarding, choose Strava import — or later open Settings → Migrate / restore → Import Strava archive
+2. During [onboarding](../getting-started/onboarding.md), choose Strava import — or later open Settings → Migrate / restore → Import Strava archive
 3. Upload the ZIP file
 4. Wait for processing to complete
 5. Review imported workouts

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -10,7 +10,9 @@ Tempo settings allow you to customize:
 - Heart rate zones
 - Relative effort calculation
 - Shoe tracking and management
-- Data export and import
+- **Export** (prominent under Data Management) and collapsed **Migrate / restore** (Strava archive + Tempo export restore)
+
+On a fresh install, units, heart rate zones, and an optional default shoe are usually set during [first-run onboarding](../getting-started/onboarding.md). You can change them anytime here.
 
 ## Appearance
 

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -215,14 +215,14 @@ To remove a shoe from your collection:
 
 ## Export / Import
 
-Tempo allows you to export all your data in a portable ZIP format for backup, migration, or data portability. You can also import previously exported data to restore your workouts, settings, and media files.
+Tempo allows you to export all your data in a portable ZIP format for backup, migration, or data portability. Under **Migrate / restore**, you can restore a previous Tempo export or import a Strava archive after onboarding.
 
 ### Exporting Your Data
 
 To export all your Tempo data:
 
 1. Navigate to Settings
-2. Find the "Export / Import" section
+2. Find the **Export** section under Data Management
 3. Click "Export All Data"
 4. Wait for the export to complete (may take a moment for large datasets)
 5. Your browser will download a ZIP file named `tempo-export-{timestamp}.zip`
@@ -300,14 +300,15 @@ Export your data for:
 - **Data Portability** - Keep a portable copy of all your data
 - **Recovery** - Restore data after accidental deletion or system failure
 
-### Importing Data
+### Importing Data {#migrate--restore}
 
-Import functionality allows you to restore data from a previously exported Tempo ZIP file. This enables you to:
+**Migrate / restore** (collapsed under Data Management) lets you restore data from a previously exported Tempo ZIP file, or import a Strava archive after onboarding. This enables you to:
 
 - Restore all workouts, media, shoes, and settings
 - Import into a new or existing Tempo instance
 - Migrate data between Tempo instances
 - Recover from data loss or accidental deletion
+- Import a late Strava archive (see [Bulk Import](bulk-import.md))
 - Handle duplicate detection automatically
 
 Settings restore runs as a background import job (same rails as [Strava bulk import](bulk-import.md)): the ZIP uploads in chunks, then Tempo restores item by item with live progress.
@@ -315,14 +316,15 @@ Settings restore runs as a background import job (same rails as [Strava bulk imp
 #### How to Import
 
 1. Navigate to Settings
-2. Find the "Export / Import" section
-3. In the "Import Data" area, click or drag and drop your Tempo export ZIP file
-4. Watch upload progress (%), then restore progress (`processed` / `total`)
-5. When finished, review the import summary showing what was imported, skipped, or had errors
+2. Under Data Management, expand **Migrate / restore**
+3. For a Tempo backup: use **Restore Tempo export** and upload your Tempo export ZIP
+4. For Strava: use **Import Strava archive** (see [Bulk Import](bulk-import.md))
+5. Watch upload progress (%), then restore/import progress (`processed` / `total`)
+6. When finished, review the summary showing what was imported, skipped, or had errors
 
 **Progress and cancel**: Large exports can take several minutes. You can cancel while uploading or restoring; items already restored stay. Re-upload the same ZIP later — duplicates are skipped (and incomplete workouts can be updated) as usual.
 
-**One import at a time**: Tempo allows only one active import job across Settings restore and the Import page’s Strava bulk import. If a Strava import is running, Settings shows a message and will not start a restore until that job finishes or is cancelled. Refreshing Settings resumes an in-progress Tempo restore.
+**One import at a time**: Tempo allows only one active import job across Tempo restore and Strava bulk import (both under Migrate / restore, or during onboarding). If the other kind is running, the UI shows a message and will not start until that job finishes or is cancelled. Refreshing Settings resumes an in-progress job.
 
 #### What Gets Imported
 
@@ -388,8 +390,8 @@ After import completes, you'll see a detailed summary including:
 - Check API logs for specific error messages
 
 **Cannot Start Import / Message About Strava**
-- Finish or cancel the Strava bulk import on the Import page first
-- Only one import job can run at a time (Settings restore or Strava bulk)
+- Finish or cancel the Strava bulk import under Settings → Migrate / restore first
+- Only one import job can run at a time (Tempo restore or Strava bulk)
 
 **Progress Seems Stuck**
 - Large restores can take 10+ minutes; watch `processed` / `total` update

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { FileUpload } from '@/components/FileUpload';
-import { BulkImport } from '@/components/BulkImport';
 import { AuthGuard } from '@/components/AuthGuard';
 import { PageShell } from '@/components/ui/PageShell';
 import { Card } from '@/components/ui/Card';
@@ -11,27 +10,14 @@ function ImportPageContent() {
     <PageShell
       density="control"
       title="Import Workouts"
-      subtitle="Upload GPX files or bulk import from Strava"
+      subtitle="Upload GPX or FIT files"
     >
       <div className="w-full space-y-8">
         <Card>
           <h2 className="text-lg font-semibold text-ink mb-4">
-            Import Single Workout
+            Import workouts
           </h2>
           <FileUpload />
-        </Card>
-
-        <Card>
-          <h2 className="text-lg font-semibold text-ink mb-2">
-            Bulk Import Strava Export
-          </h2>
-          <p className="text-sm text-muted mb-4">
-            Upload a ZIP file containing your Strava data export. The ZIP should include{' '}
-            <code className="px-1 py-0.5 bg-canvas border border-border rounded-tempo text-ink">activities.csv</code>{' '}
-            and an <code className="px-1 py-0.5 bg-canvas border border-border rounded-tempo text-ink">activities/</code>{' '}
-            folder with GPX or FIT files.
-          </p>
-          <BulkImport />
         </Card>
       </div>
     </PageShell>

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -25,13 +25,13 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [registrationAvailable, setRegistrationAvailable] = useState(false);
-  const { login, register, isAuthenticated } = useAuth();
+  const { login, register, isAuthenticated, user } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
-    // If already authenticated, redirect to dashboard
-    if (isAuthenticated) {
-      router.push('/dashboard');
+    // If already authenticated, redirect based on onboarding state
+    if (isAuthenticated && user) {
+      router.push(user.onboardingCompleted ? '/dashboard' : '/onboarding');
       return;
     }
 
@@ -48,8 +48,10 @@ export default function LoginPage() {
       }
     };
 
-    checkRegistration();
-  }, [isAuthenticated, router]);
+    if (!isAuthenticated) {
+      checkRegistration();
+    }
+  }, [isAuthenticated, user, router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -88,6 +88,7 @@ export default function LoginPage() {
   return (
     <PageShell
       density="control"
+      centered
       title={isRegistering ? 'Create Account' : 'Sign in to Tempo'}
       subtitle={
         isRegistering
@@ -95,7 +96,7 @@ export default function LoginPage() {
           : 'Enter your credentials to access your workouts'
       }
     >
-      <Card className="max-w-md mx-auto space-y-6">
+      <Card className="w-full max-w-md space-y-6">
         {isRegistering && (
           <p className="text-xs text-muted">
             Use a memorable passphrase, {PASSWORD_MIN_LENGTH}–{PASSWORD_MAX_LENGTH} characters. Spaces and

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -113,14 +113,19 @@ function OnboardingWizard() {
   }
 
   return (
-    <PageShell density="control" title={stepTitle(step)} subtitle={stepSubtitle(step)}>
+    <PageShell
+      density="control"
+      centered
+      title={stepTitle(step)}
+      subtitle={stepSubtitle(step)}
+    >
       {step === 'ask_restore' ? (
-        <Card className="max-w-lg space-y-4">
+        <Card className="w-full max-w-md space-y-4">
           <p className="text-sm text-muted">
             Restoring brings back settings, shoes, workouts, and media from a Tempo export ZIP.
             If this is a new install, choose no and configure essentials next.
           </p>
-          <div className="flex flex-wrap gap-3">
+          <div className="flex flex-wrap gap-3 justify-center">
             <Button onClick={() => setStep('tempo_restore')}>Yes, restore export</Button>
             <Button variant="secondary" onClick={goEssentials}>
               No, set up fresh
@@ -130,7 +135,7 @@ function OnboardingWizard() {
       ) : null}
 
       {step === 'tempo_restore' ? (
-        <div className="space-y-4 max-w-2xl">
+        <div className="w-full max-w-lg space-y-4">
           <TempoExportImport
             key={restoreKey}
             onJobCompleted={handleRestoreCompleted}
@@ -142,7 +147,7 @@ function OnboardingWizard() {
                 Restore did not finish. Retry with another ZIP, or set up this install fresh
                 without marking onboarding complete yet.
               </p>
-              <div className="flex flex-wrap gap-3">
+              <div className="flex flex-wrap gap-3 justify-center">
                 <Button
                   variant="secondary"
                   onClick={() => {
@@ -159,20 +164,24 @@ function OnboardingWizard() {
             </Card>
           ) : null}
           {error ? (
-            <p className="text-sm text-danger" role="alert">
+            <p className="text-sm text-danger text-center" role="alert">
               {error}
             </p>
           ) : null}
-          {isCompleting ? <p className="text-sm text-muted">Finishing setup…</p> : null}
+          {isCompleting ? (
+            <p className="text-sm text-muted text-center">Finishing setup…</p>
+          ) : null}
         </div>
       ) : null}
 
       {step === 'essentials' ? (
-        <EssentialsStep onContinue={() => setStep('ask_strava')} />
+        <div className="w-full max-w-lg">
+          <EssentialsStep onContinue={() => setStep('ask_strava')} />
+        </div>
       ) : null}
 
       {step === 'ask_strava' ? (
-        <Card className="max-w-lg space-y-4">
+        <Card className="w-full max-w-md space-y-4">
           <p className="text-sm text-muted">
             You can import a Strava bulk export ZIP during setup, or skip and add individual
             GPX/FIT files later from Import. Late Strava archives also live under Settings →
@@ -183,7 +192,7 @@ function OnboardingWizard() {
               {error}
             </p>
           ) : null}
-          <div className="flex flex-wrap gap-3">
+          <div className="flex flex-wrap gap-3 justify-center">
             <Button
               onClick={() => {
                 setStravaFailed(false);
@@ -205,7 +214,7 @@ function OnboardingWizard() {
       ) : null}
 
       {step === 'strava_upload' ? (
-        <div className="space-y-4 max-w-2xl">
+        <div className="w-full max-w-lg space-y-4">
           <BulkImport
             key={stravaKey}
             onJobCompleted={handleStravaCompleted}
@@ -217,7 +226,7 @@ function OnboardingWizard() {
                 Strava import did not finish. Retry with another ZIP, or skip and finish setup
                 — you can import a Strava archive later from Settings → Migrate / restore.
               </p>
-              <div className="flex flex-wrap gap-3">
+              <div className="flex flex-wrap gap-3 justify-center">
                 <Button
                   variant="secondary"
                   onClick={() => {
@@ -234,23 +243,27 @@ function OnboardingWizard() {
               </div>
             </Card>
           ) : (
-            <Button
-              variant="secondary"
-              onClick={() => {
-                setStravaFailed(false);
-                setStep('ask_strava');
-              }}
-              disabled={isCompleting}
-            >
-              Back
-            </Button>
+            <div className="flex justify-center">
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  setStravaFailed(false);
+                  setStep('ask_strava');
+                }}
+                disabled={isCompleting}
+              >
+                Back
+              </Button>
+            </div>
           )}
           {error ? (
-            <p className="text-sm text-danger" role="alert">
+            <p className="text-sm text-danger text-center" role="alert">
               {error}
             </p>
           ) : null}
-          {isCompleting ? <p className="text-sm text-muted">Finishing setup…</p> : null}
+          {isCompleting ? (
+            <p className="text-sm text-muted text-center">Finishing setup…</p>
+          ) : null}
         </div>
       ) : null}
     </PageShell>

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -175,7 +175,8 @@ function OnboardingWizard() {
         <Card className="max-w-lg space-y-4">
           <p className="text-sm text-muted">
             You can import a Strava bulk export ZIP during setup, or skip and add individual
-            GPX/FIT files later from Import.
+            GPX/FIT files later from Import. Late Strava archives also live under Settings →
+            Migrate / restore.
           </p>
           {error ? (
             <p className="text-sm text-danger" role="alert">
@@ -214,7 +215,7 @@ function OnboardingWizard() {
             <Card className="space-y-3">
               <p className="text-sm text-muted">
                 Strava import did not finish. Retry with another ZIP, or skip and finish setup
-                — you can import later from Import.
+                — you can import a Strava archive later from Settings → Migrate / restore.
               </p>
               <div className="flex flex-wrap gap-3">
                 <Button

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { AuthGuard } from '@/components/AuthGuard';
+import { BulkImport } from '@/components/BulkImport';
 import { TempoExportImport } from '@/components/TempoExportImport';
 import { EssentialsStep } from '@/components/onboarding/EssentialsStep';
 import { PageShell } from '@/components/ui/PageShell';
@@ -16,7 +17,7 @@ type OnboardingStep =
   | 'tempo_restore'
   | 'essentials'
   | 'ask_strava'
-  | 'strava_stub';
+  | 'strava_upload';
 
 function stepTitle(step: OnboardingStep): string {
   switch (step) {
@@ -28,8 +29,8 @@ function stepTitle(step: OnboardingStep): string {
       return 'Essential settings';
     case 'ask_strava':
       return 'Import from Strava?';
-    case 'strava_stub':
-      return 'Strava import';
+    case 'strava_upload':
+      return 'Import Strava archive';
   }
 }
 
@@ -43,8 +44,8 @@ function stepSubtitle(step: OnboardingStep): string {
       return 'Set units and heart rate zones before you import runs. A default shoe is optional.';
     case 'ask_strava':
       return 'If you have a Strava archive, you can import it after essentials.';
-    case 'strava_stub':
-      return 'Strava archive upload lands in a following update. You can finish setup now.';
+    case 'strava_upload':
+      return 'Upload a Strava export ZIP that includes activities.csv and an activities/ folder.';
   }
 }
 
@@ -53,9 +54,11 @@ function OnboardingWizard() {
   const router = useRouter();
   const [step, setStep] = useState<OnboardingStep>('ask_restore');
   const [restoreFailed, setRestoreFailed] = useState(false);
+  const [stravaFailed, setStravaFailed] = useState(false);
   const [isCompleting, setIsCompleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [restoreKey, setRestoreKey] = useState(0);
+  const [stravaKey, setStravaKey] = useState(0);
 
   useEffect(() => {
     if (user?.onboardingCompleted) {
@@ -94,6 +97,15 @@ function OnboardingWizard() {
 
   const handleRestoreFailed = useCallback(() => {
     setRestoreFailed(true);
+  }, []);
+
+  const handleStravaCompleted = useCallback(async () => {
+    setStravaFailed(false);
+    await finish();
+  }, [finish]);
+
+  const handleStravaFailed = useCallback(() => {
+    setStravaFailed(true);
   }, []);
 
   if (user?.onboardingCompleted) {
@@ -171,7 +183,13 @@ function OnboardingWizard() {
             </p>
           ) : null}
           <div className="flex flex-wrap gap-3">
-            <Button onClick={() => setStep('strava_stub')} disabled={isCompleting}>
+            <Button
+              onClick={() => {
+                setStravaFailed(false);
+                setStep('strava_upload');
+              }}
+              disabled={isCompleting}
+            >
               Yes, I have a Strava archive
             </Button>
             <Button
@@ -185,30 +203,54 @@ function OnboardingWizard() {
         </Card>
       ) : null}
 
-      {step === 'strava_stub' ? (
-        <Card className="max-w-lg space-y-4">
-          <p className="text-sm text-muted">
-            Strava archive upload will be available here in a following update. You can skip for
-            now and finish onboarding — bulk Strava import will also live under Settings later.
-          </p>
+      {step === 'strava_upload' ? (
+        <div className="space-y-4 max-w-2xl">
+          <BulkImport
+            key={stravaKey}
+            onJobCompleted={handleStravaCompleted}
+            onJobFailedOrCancelled={handleStravaFailed}
+          />
+          {stravaFailed ? (
+            <Card className="space-y-3">
+              <p className="text-sm text-muted">
+                Strava import did not finish. Retry with another ZIP, or skip and finish setup
+                — you can import later from Import.
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <Button
+                  variant="secondary"
+                  onClick={() => {
+                    setStravaFailed(false);
+                    setStravaKey((k) => k + 1);
+                  }}
+                  disabled={isCompleting}
+                >
+                  Retry
+                </Button>
+                <Button onClick={() => void finish()} disabled={isCompleting}>
+                  {isCompleting ? 'Finishing…' : 'Skip for now'}
+                </Button>
+              </div>
+            </Card>
+          ) : (
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setStravaFailed(false);
+                setStep('ask_strava');
+              }}
+              disabled={isCompleting}
+            >
+              Back
+            </Button>
+          )}
           {error ? (
             <p className="text-sm text-danger" role="alert">
               {error}
             </p>
           ) : null}
-          <div className="flex flex-wrap gap-3">
-            <Button onClick={() => void finish()} disabled={isCompleting}>
-              {isCompleting ? 'Finishing…' : 'Skip for now'}
-            </Button>
-            <Button
-              variant="secondary"
-              onClick={() => setStep('ask_strava')}
-              disabled={isCompleting}
-            >
-              Back
-            </Button>
-          </div>
-        </Card>
+          {isCompleting ? <p className="text-sm text-muted">Finishing setup…</p> : null}
+        </div>
       ) : null}
     </PageShell>
   );

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -1,18 +1,61 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { AuthGuard } from '@/components/AuthGuard';
+import { TempoExportImport } from '@/components/TempoExportImport';
+import { EssentialsStep } from '@/components/onboarding/EssentialsStep';
 import { PageShell } from '@/components/ui/PageShell';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { useAuth } from '@/contexts/AuthContext';
+import { importJobHasSettings, type ImportJob } from '@/lib/api';
 
-function OnboardingStub() {
+type OnboardingStep =
+  | 'ask_restore'
+  | 'tempo_restore'
+  | 'essentials'
+  | 'ask_strava'
+  | 'strava_stub';
+
+function stepTitle(step: OnboardingStep): string {
+  switch (step) {
+    case 'ask_restore':
+      return 'Welcome to Tempo';
+    case 'tempo_restore':
+      return 'Restore from Tempo export';
+    case 'essentials':
+      return 'Essential settings';
+    case 'ask_strava':
+      return 'Import from Strava?';
+    case 'strava_stub':
+      return 'Strava import';
+  }
+}
+
+function stepSubtitle(step: OnboardingStep): string {
+  switch (step) {
+    case 'ask_restore':
+      return 'Start by restoring a previous Tempo export, or set up this install fresh.';
+    case 'tempo_restore':
+      return 'Upload a Tempo export ZIP. Settings, shoes, workouts, and media come back together.';
+    case 'essentials':
+      return 'Set units and heart rate zones before you import runs. A default shoe is optional.';
+    case 'ask_strava':
+      return 'If you have a Strava archive, you can import it after essentials.';
+    case 'strava_stub':
+      return 'Strava archive upload lands in a following update. You can finish setup now.';
+  }
+}
+
+function OnboardingWizard() {
   const { user, completeOnboarding } = useAuth();
   const router = useRouter();
-  const [isFinishing, setIsFinishing] = useState(false);
+  const [step, setStep] = useState<OnboardingStep>('ask_restore');
+  const [restoreFailed, setRestoreFailed] = useState(false);
+  const [isCompleting, setIsCompleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [restoreKey, setRestoreKey] = useState(0);
 
   useEffect(() => {
     if (user?.onboardingCompleted) {
@@ -20,41 +63,153 @@ function OnboardingStub() {
     }
   }, [user, router]);
 
-  if (user?.onboardingCompleted) {
-    return null;
-  }
-
-  const handleFinish = async () => {
+  const finish = useCallback(async () => {
     setError(null);
-    setIsFinishing(true);
+    setIsCompleting(true);
     try {
       await completeOnboarding();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to finish setup');
-      setIsFinishing(false);
+      setIsCompleting(false);
     }
-  };
+  }, [completeOnboarding]);
+
+  const goEssentials = useCallback(() => {
+    setError(null);
+    setRestoreFailed(false);
+    setStep('essentials');
+  }, []);
+
+  const handleRestoreCompleted = useCallback(
+    async (job: ImportJob) => {
+      setRestoreFailed(false);
+      if (importJobHasSettings(job)) {
+        await finish();
+        return;
+      }
+      goEssentials();
+    },
+    [finish, goEssentials]
+  );
+
+  const handleRestoreFailed = useCallback(() => {
+    setRestoreFailed(true);
+  }, []);
+
+  if (user?.onboardingCompleted) {
+    return null;
+  }
 
   return (
-    <PageShell
-      density="control"
-      title="Welcome to Tempo"
-      subtitle="Finish setup to start tracking your runs."
-    >
-      <Card className="max-w-lg space-y-4">
-        <p className="text-sm text-muted">
-          This temporary step marks your account as set up. Guided restore,
-          settings, and Strava import will land here in a later update.
-        </p>
-        {error ? (
-          <p className="text-sm text-danger" role="alert">
-            {error}
+    <PageShell density="control" title={stepTitle(step)} subtitle={stepSubtitle(step)}>
+      {step === 'ask_restore' ? (
+        <Card className="max-w-lg space-y-4">
+          <p className="text-sm text-muted">
+            Restoring brings back settings, shoes, workouts, and media from a Tempo export ZIP.
+            If this is a new install, choose no and configure essentials next.
           </p>
-        ) : null}
-        <Button onClick={handleFinish} disabled={isFinishing}>
-          {isFinishing ? 'Finishing…' : 'Finish setup'}
-        </Button>
-      </Card>
+          <div className="flex flex-wrap gap-3">
+            <Button onClick={() => setStep('tempo_restore')}>Yes, restore export</Button>
+            <Button variant="secondary" onClick={goEssentials}>
+              No, set up fresh
+            </Button>
+          </div>
+        </Card>
+      ) : null}
+
+      {step === 'tempo_restore' ? (
+        <div className="space-y-4 max-w-2xl">
+          <TempoExportImport
+            key={restoreKey}
+            onJobCompleted={handleRestoreCompleted}
+            onJobFailedOrCancelled={handleRestoreFailed}
+          />
+          {restoreFailed ? (
+            <Card className="space-y-3">
+              <p className="text-sm text-muted">
+                Restore did not finish. Retry with another ZIP, or set up this install fresh
+                without marking onboarding complete yet.
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <Button
+                  variant="secondary"
+                  onClick={() => {
+                    setRestoreFailed(false);
+                    setRestoreKey((k) => k + 1);
+                  }}
+                >
+                  Retry
+                </Button>
+                <Button variant="secondary" onClick={goEssentials}>
+                  Set up fresh instead
+                </Button>
+              </div>
+            </Card>
+          ) : null}
+          {error ? (
+            <p className="text-sm text-danger" role="alert">
+              {error}
+            </p>
+          ) : null}
+          {isCompleting ? <p className="text-sm text-muted">Finishing setup…</p> : null}
+        </div>
+      ) : null}
+
+      {step === 'essentials' ? (
+        <EssentialsStep onContinue={() => setStep('ask_strava')} />
+      ) : null}
+
+      {step === 'ask_strava' ? (
+        <Card className="max-w-lg space-y-4">
+          <p className="text-sm text-muted">
+            You can import a Strava bulk export ZIP during setup, or skip and add individual
+            GPX/FIT files later from Import.
+          </p>
+          {error ? (
+            <p className="text-sm text-danger" role="alert">
+              {error}
+            </p>
+          ) : null}
+          <div className="flex flex-wrap gap-3">
+            <Button onClick={() => setStep('strava_stub')} disabled={isCompleting}>
+              Yes, I have a Strava archive
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => void finish()}
+              disabled={isCompleting}
+            >
+              {isCompleting ? 'Finishing…' : 'No, finish setup'}
+            </Button>
+          </div>
+        </Card>
+      ) : null}
+
+      {step === 'strava_stub' ? (
+        <Card className="max-w-lg space-y-4">
+          <p className="text-sm text-muted">
+            Strava archive upload will be available here in a following update. You can skip for
+            now and finish onboarding — bulk Strava import will also live under Settings later.
+          </p>
+          {error ? (
+            <p className="text-sm text-danger" role="alert">
+              {error}
+            </p>
+          ) : null}
+          <div className="flex flex-wrap gap-3">
+            <Button onClick={() => void finish()} disabled={isCompleting}>
+              {isCompleting ? 'Finishing…' : 'Skip for now'}
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => setStep('ask_strava')}
+              disabled={isCompleting}
+            >
+              Back
+            </Button>
+          </div>
+        </Card>
+      ) : null}
     </PageShell>
   );
 }
@@ -62,7 +217,7 @@ function OnboardingStub() {
 export default function OnboardingPage() {
   return (
     <AuthGuard>
-      <OnboardingStub />
+      <OnboardingWizard />
     </AuthGuard>
   );
 }

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { AuthGuard } from '@/components/AuthGuard';
+import { PageShell } from '@/components/ui/PageShell';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { useAuth } from '@/contexts/AuthContext';
+
+function OnboardingStub() {
+  const { user, completeOnboarding } = useAuth();
+  const router = useRouter();
+  const [isFinishing, setIsFinishing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (user?.onboardingCompleted) {
+      router.replace('/dashboard');
+    }
+  }, [user, router]);
+
+  if (user?.onboardingCompleted) {
+    return null;
+  }
+
+  const handleFinish = async () => {
+    setError(null);
+    setIsFinishing(true);
+    try {
+      await completeOnboarding();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to finish setup');
+      setIsFinishing(false);
+    }
+  };
+
+  return (
+    <PageShell
+      density="control"
+      title="Welcome to Tempo"
+      subtitle="Finish setup to start tracking your runs."
+    >
+      <Card className="max-w-lg space-y-4">
+        <p className="text-sm text-muted">
+          This temporary step marks your account as set up. Guided restore,
+          settings, and Strava import will land here in a later update.
+        </p>
+        {error ? (
+          <p className="text-sm text-danger" role="alert">
+            {error}
+          </p>
+        ) : null}
+        <Button onClick={handleFinish} disabled={isFinishing}>
+          {isFinishing ? 'Finishing…' : 'Finish setup'}
+        </Button>
+      </Card>
+    </PageShell>
+  );
+}
+
+export default function OnboardingPage() {
+  return (
+    <AuthGuard>
+      <OnboardingStub />
+    </AuthGuard>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -6,17 +6,17 @@ import { useAuth } from '@/contexts/AuthContext';
 
 export default function Home() {
   const router = useRouter();
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading, user } = useAuth();
 
   useEffect(() => {
     if (!isLoading) {
-      if (isAuthenticated) {
-        router.push('/dashboard');
-      } else {
+      if (isAuthenticated && user) {
+        router.push(user.onboardingCompleted ? '/dashboard' : '/onboarding');
+      } else if (!isAuthenticated) {
         router.push('/login');
       }
     }
-  }, [isAuthenticated, isLoading, router]);
+  }, [isAuthenticated, isLoading, user, router]);
 
   // Show loading state while checking
   return (

--- a/frontend/components/AuthGuard.tsx
+++ b/frontend/components/AuthGuard.tsx
@@ -1,18 +1,32 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading, user } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
-      router.push('/login');
+    if (isLoading) {
+      return;
     }
-  }, [isAuthenticated, isLoading, router]);
+
+    if (!isAuthenticated) {
+      router.replace('/login');
+      return;
+    }
+
+    if (
+      user &&
+      !user.onboardingCompleted &&
+      pathname !== '/onboarding'
+    ) {
+      router.replace('/onboarding');
+    }
+  }, [isAuthenticated, isLoading, user, pathname, router]);
 
   if (isLoading) {
     return (
@@ -26,6 +40,9 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
     return null;
   }
 
+  if (user && !user.onboardingCompleted && pathname !== '/onboarding') {
+    return null;
+  }
+
   return <>{children}</>;
 }
-

--- a/frontend/components/BulkImport.tsx
+++ b/frontend/components/BulkImport.tsx
@@ -14,25 +14,40 @@ import { useImportJobSession } from '@/hooks/useImportJobSession';
 import { IconUpload } from '@tabler/icons-react';
 import { Button } from '@/components/ui/Button';
 
-export function BulkImport() {
+export type BulkImportProps = {
+  onJobCompleted?: (job: ImportJob) => void | Promise<void>;
+  onJobFailedOrCancelled?: (message: string) => void;
+};
+
+export function BulkImport(props: BulkImportProps = {}) {
+  const { onJobCompleted, onJobFailedOrCancelled } = props;
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [importResult, setImportResult] = useState<BulkImportResponse | null>(null);
   const { unitPreference } = useSettings();
   const queryClient = useQueryClient();
 
   const onCompleted = useCallback(
-    (job: ImportJob) => {
+    async (job: ImportJob) => {
       invalidateWorkoutQueries(queryClient);
       setImportResult(importJobToBulkResponse(job));
       setSelectedFile(null);
+      await onJobCompleted?.(job);
     },
-    [queryClient]
+    [queryClient, onJobCompleted]
+  );
+
+  const onFailed = useCallback(
+    (message: string) => {
+      onJobFailedOrCancelled?.(message);
+    },
+    [onJobFailedOrCancelled]
   );
 
   const session = useImportJobSession({
     kind: 'strava_bulk',
     unitPreference,
     onCompleted,
+    onFailed,
   });
 
   const {

--- a/frontend/components/ExportImportSection.tsx
+++ b/frontend/components/ExportImportSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { TempoExportImport } from './TempoExportImport';
+import { BulkImport } from './BulkImport';
 import { exportAllData } from '@/lib/api';
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
@@ -44,18 +45,17 @@ export function ExportImportSection() {
 
   return (
     <Card>
-      <h2 className="text-lg font-semibold text-ink mb-4">Export / Import</h2>
+      <h2 className="text-lg font-semibold text-ink mb-4">Export</h2>
       <p className="text-sm text-muted mb-6">
-        Export all your Tempo data including workouts, media files, shoes, settings, and best efforts in a portable ZIP format. 
-        You can use this export to back up your data or migrate to a new instance.
+        Download a complete backup of all your Tempo data as a ZIP file. The export includes workouts,
+        media, shoes, settings, and calculated data. Use it for backups or migrating to a new instance.
       </p>
 
       <div className="space-y-4">
         <div>
           <h3 className="text-md font-medium text-ink mb-2">Export Data</h3>
           <p className="text-sm text-muted mb-4">
-            Download a complete backup of all your Tempo data as a ZIP file. The export includes all workouts, 
-            media files, shoes, settings, and calculated data.
+            Download a complete backup of all your Tempo data as a ZIP file.
           </p>
           <div className="flex flex-col gap-2">
             <Button
@@ -78,14 +78,45 @@ export function ExportImportSection() {
           </div>
         </div>
 
-        <div className="pt-4 border-t border-border">
-          <h3 className="text-md font-medium text-ink mb-2">Import Data</h3>
-          <p className="text-sm text-muted mb-4">
-            Import a previously exported Tempo backup file to restore your data. This will restore all workouts, 
-            media files, shoes, settings, and calculated data. Duplicates will be skipped automatically.
-          </p>
-          <TempoExportImport />
-        </div>
+        <details className="pt-4 border-t border-border group">
+          <summary className="cursor-pointer list-none flex items-center justify-between gap-2">
+            <div>
+              <h3 className="text-md font-medium text-ink">Migrate / restore</h3>
+              <p className="text-sm text-muted mt-1">
+                Restore a Tempo export or import a Strava archive after onboarding. Expand to upload a ZIP.
+              </p>
+            </div>
+            <span className="text-muted text-sm shrink-0 group-open:hidden">Show</span>
+            <span className="text-muted text-sm shrink-0 hidden group-open:inline">Hide</span>
+          </summary>
+
+          <div className="mt-4 space-y-8">
+            <div>
+              <h4 className="text-sm font-medium text-ink mb-2">Restore Tempo export</h4>
+              <p className="text-sm text-muted mb-4">
+                Import a previously exported Tempo backup. Workouts, media, shoes, settings, and
+                calculated data are restored; duplicates are skipped automatically.
+              </p>
+              <TempoExportImport />
+            </div>
+
+            <div className="pt-4 border-t border-border">
+              <h4 className="text-sm font-medium text-ink mb-2">Import Strava archive</h4>
+              <p className="text-sm text-muted mb-4">
+                Upload a Strava data export ZIP that includes{' '}
+                <code className="px-1 py-0.5 bg-canvas border border-border rounded-tempo text-ink">
+                  activities.csv
+                </code>{' '}
+                and an{' '}
+                <code className="px-1 py-0.5 bg-canvas border border-border rounded-tempo text-ink">
+                  activities/
+                </code>{' '}
+                folder with GPX or FIT files.
+              </p>
+              <BulkImport />
+            </div>
+          </div>
+        </details>
       </div>
     </Card>
   );

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -9,6 +9,14 @@ export function Navbar() {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
   const { isAuthenticated, logout } = useAuth();
+  const isOnboarding = pathname === '/onboarding';
+  const showAppLinks = isAuthenticated && !isOnboarding;
+
+  const brandHref = !isAuthenticated
+    ? '/login'
+    : isOnboarding
+      ? '/onboarding'
+      : '/dashboard';
 
   const isActive = (path: string) => {
     if (path === '/dashboard') {
@@ -40,7 +48,7 @@ export function Navbar() {
         <div className="flex items-center justify-between h-16">
           <div className="flex-shrink-0">
             <Link
-              href={isAuthenticated ? '/dashboard' : '/login'}
+              href={brandHref}
               className="flex items-center gap-2.5 text-ink hover:opacity-80 transition-opacity"
             >
               <span className="relative inline-flex h-8 w-8 shrink-0">
@@ -66,7 +74,7 @@ export function Navbar() {
           </div>
 
           <div className="flex items-center">
-            {isAuthenticated && (
+            {showAppLinks && (
               <div className="hidden md:flex items-center space-x-1">
                 <Link href="/dashboard" className={navLinkClasses('/dashboard')}>
                   Dashboard
@@ -94,31 +102,33 @@ export function Navbar() {
               </div>
             )}
 
-            <button
-              type="button"
-              className="md:hidden inline-flex flex-col items-center justify-center gap-1.5 p-2 rounded-tempo text-muted hover:text-ink hover:bg-canvas focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-volt focus:ring-offset-raised"
-              aria-label="Toggle navigation menu"
-              aria-expanded={mobileOpen}
-              aria-controls="mobile-menu"
-              onClick={() => setMobileOpen((open) => !open)}
-            >
-              <span className="sr-only">Open main menu</span>
-              <span
-                className={`block h-0.5 w-5 rounded-sm bg-current transition-transform ${
-                  mobileOpen ? 'translate-y-1.5 rotate-45' : ''
-                }`}
-              />
-              <span
-                className={`block h-0.5 w-5 rounded-sm bg-current transition-opacity ${
-                  mobileOpen ? 'opacity-0' : 'opacity-100'
-                }`}
-              />
-              <span
-                className={`block h-0.5 w-5 rounded-sm bg-current transition-transform ${
-                  mobileOpen ? '-translate-y-1.5 -rotate-45' : ''
-                }`}
-              />
-            </button>
+            {isAuthenticated && (
+              <button
+                type="button"
+                className="md:hidden inline-flex flex-col items-center justify-center gap-1.5 p-2 rounded-tempo text-muted hover:text-ink hover:bg-canvas focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-volt focus:ring-offset-raised"
+                aria-label="Toggle navigation menu"
+                aria-expanded={mobileOpen}
+                aria-controls="mobile-menu"
+                onClick={() => setMobileOpen((open) => !open)}
+              >
+                <span className="sr-only">Open main menu</span>
+                <span
+                  className={`block h-0.5 w-5 rounded-sm bg-current transition-transform ${
+                    mobileOpen ? 'translate-y-1.5 rotate-45' : ''
+                  }`}
+                />
+                <span
+                  className={`block h-0.5 w-5 rounded-sm bg-current transition-opacity ${
+                    mobileOpen ? 'opacity-0' : 'opacity-100'
+                  }`}
+                />
+                <span
+                  className={`block h-0.5 w-5 rounded-sm bg-current transition-transform ${
+                    mobileOpen ? '-translate-y-1.5 -rotate-45' : ''
+                  }`}
+                />
+              </button>
+            )}
           </div>
         </div>
 
@@ -129,34 +139,38 @@ export function Navbar() {
               mobileOpen ? 'block' : 'hidden'
             }`}
           >
-            <Link
-              href="/dashboard"
-              className={navLinkClasses('/dashboard')}
-              onClick={() => setMobileOpen(false)}
-            >
-              Dashboard
-            </Link>
-            <Link
-              href="/activities"
-              className={navLinkClasses('/activities')}
-              onClick={() => setMobileOpen(false)}
-            >
-              Activities
-            </Link>
-            <Link
-              href="/import"
-              className={navLinkClasses('/import')}
-              onClick={() => setMobileOpen(false)}
-            >
-              Import
-            </Link>
-            <Link
-              href="/settings"
-              className={navLinkClasses('/settings')}
-              onClick={() => setMobileOpen(false)}
-            >
-              Settings
-            </Link>
+            {showAppLinks && (
+              <>
+                <Link
+                  href="/dashboard"
+                  className={navLinkClasses('/dashboard')}
+                  onClick={() => setMobileOpen(false)}
+                >
+                  Dashboard
+                </Link>
+                <Link
+                  href="/activities"
+                  className={navLinkClasses('/activities')}
+                  onClick={() => setMobileOpen(false)}
+                >
+                  Activities
+                </Link>
+                <Link
+                  href="/import"
+                  className={navLinkClasses('/import')}
+                  onClick={() => setMobileOpen(false)}
+                >
+                  Import
+                </Link>
+                <Link
+                  href="/settings"
+                  className={navLinkClasses('/settings')}
+                  onClick={() => setMobileOpen(false)}
+                >
+                  Settings
+                </Link>
+              </>
+            )}
             <button
               onClick={() => {
                 logout();

--- a/frontend/components/TempoExportImport.tsx
+++ b/frontend/components/TempoExportImport.tsx
@@ -15,7 +15,13 @@ import { useSettings } from '@/lib/settings';
 import { IconUpload } from '@tabler/icons-react';
 import { Button } from '@/components/ui/Button';
 
-export function TempoExportImport() {
+export type TempoExportImportProps = {
+  onJobCompleted?: (job: ImportJob) => void | Promise<void>;
+  onJobFailedOrCancelled?: (message: string) => void;
+};
+
+export function TempoExportImport(props: TempoExportImportProps = {}) {
+  const { onJobCompleted, onJobFailedOrCancelled } = props;
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [importResult, setImportResult] = useState<ExportImportResponse | null>(null);
   const queryClient = useQueryClient();
@@ -34,13 +40,22 @@ export function TempoExportImport() {
       }
       setImportResult(importJobToExportImportResponse(job));
       setSelectedFile(null);
+      await onJobCompleted?.(job);
     },
-    [queryClient, setUnitPreference]
+    [queryClient, setUnitPreference, onJobCompleted]
+  );
+
+  const onFailed = useCallback(
+    (message: string) => {
+      onJobFailedOrCancelled?.(message);
+    },
+    [onJobFailedOrCancelled]
   );
 
   const session = useImportJobSession({
     kind: 'tempo_export',
     onCompleted,
+    onFailed,
   });
 
   const {

--- a/frontend/components/onboarding/EssentialsStep.tsx
+++ b/frontend/components/onboarding/EssentialsStep.tsx
@@ -398,7 +398,10 @@ export function EssentialsStep({ onContinue }: EssentialsStepProps) {
         >
           <div>
             <h2 className="text-lg font-semibold text-ink">Add a default shoe</h2>
-            <p className="mt-1 text-sm text-muted">Optional — skip if you do not care yet.</p>
+            <p className="mt-1 text-sm text-muted">
+              Optional — skip if you do not care yet. If you set a default, new imported activities
+              are automatically tagged with that shoe (you can change this later in Settings).
+            </p>
           </div>
           <span className="text-sm text-muted">{shoeOpen ? 'Hide' : 'Show'}</span>
         </button>

--- a/frontend/components/onboarding/EssentialsStep.tsx
+++ b/frontend/components/onboarding/EssentialsStep.tsx
@@ -1,0 +1,480 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  createShoe,
+  getHeartRateZones,
+  setDefaultShoe,
+  updateHeartRateZones,
+  updateUnitPreference,
+  type HeartRateCalculationMethod,
+  type HeartRateZoneSettings,
+  type UpdateHeartRateZoneSettingsRequest,
+} from '@/lib/api';
+import { useHeartRateZones } from '@/hooks/useHeartRateZones';
+import { useSettings } from '@/lib/settings';
+import { formatDistance, formatElevation, formatPace } from '@/lib/format';
+import { Button } from '@/components/ui/Button';
+import { Card } from '@/components/ui/Card';
+
+const fieldClass =
+  'w-full px-3 py-2 border border-border rounded-tempo bg-canvas text-ink focus:outline-none focus:ring-2 focus:ring-volt';
+
+type EssentialsStepProps = {
+  onContinue: () => void;
+};
+
+export function EssentialsStep({ onContinue }: EssentialsStepProps) {
+  const { unitPreference, setUnitPreference } = useSettings();
+  const [hrZones, setHrZones] = useState<HeartRateZoneSettings | null>(null);
+  const [isLoadingHr, setIsLoadingHr] = useState(true);
+  const [unitsSaved, setUnitsSaved] = useState(false);
+  const [hrSaved, setHrSaved] = useState(false);
+  const [isSavingHr, setIsSavingHr] = useState(false);
+  const [hrError, setHrError] = useState<string | null>(null);
+  const [continueError, setContinueError] = useState<string | null>(null);
+  const [isContinuing, setIsContinuing] = useState(false);
+
+  const [shoeOpen, setShoeOpen] = useState(false);
+  const [shoeBrand, setShoeBrand] = useState('');
+  const [shoeModel, setShoeModel] = useState('');
+  const [shoeMileageInput, setShoeMileageInput] = useState('');
+  const [shoeSaving, setShoeSaving] = useState(false);
+  const [shoeError, setShoeError] = useState<string | null>(null);
+  const [shoeSuccess, setShoeSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const settings = await getHeartRateZones();
+        if (!cancelled) {
+          setHrZones(settings);
+        }
+      } catch (error) {
+        console.error('Failed to load heart rate zones:', error);
+      } finally {
+        if (!cancelled) {
+          setIsLoadingHr(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const {
+    calculationMethod,
+    setCalculationMethod,
+    age,
+    setAge,
+    restingHr,
+    setRestingHr,
+    maxHr,
+    setMaxHr,
+    customZones,
+    displayZones,
+    updateCustomZone,
+  } = useHeartRateZones(hrZones);
+
+  const selectUnit = async (unit: 'metric' | 'imperial') => {
+    await setUnitPreference(unit);
+    setUnitsSaved(true);
+  };
+
+  const handleSaveHrZones = async () => {
+    setIsSavingHr(true);
+    setHrError(null);
+    try {
+      const request: UpdateHeartRateZoneSettingsRequest = {
+        calculationMethod,
+        age: calculationMethod === 'AgeBased' ? age : null,
+        restingHeartRateBpm: calculationMethod === 'Karvonen' ? restingHr : null,
+        maxHeartRateBpm: calculationMethod === 'Karvonen' ? maxHr : null,
+        zones:
+          calculationMethod === 'Custom'
+            ? displayZones.map((z, i) => ({
+                zoneNumber: i + 1,
+                minBpm: z.min,
+                maxBpm: z.max,
+              }))
+            : undefined,
+      };
+      const updated = await updateHeartRateZones(request);
+      setHrZones(updated);
+      setHrSaved(true);
+    } catch (error) {
+      setHrError(error instanceof Error ? error.message : 'Failed to save heart rate zones');
+      setHrSaved(false);
+    } finally {
+      setIsSavingHr(false);
+    }
+  };
+
+  const convertToMeters = (value: number, unit: 'metric' | 'imperial'): number =>
+    unit === 'imperial' ? value * 1609.344 : value * 1000;
+
+  const handleCreateShoe = async () => {
+    if (!shoeBrand.trim() || !shoeModel.trim()) {
+      setShoeError('Brand and model are required');
+      return;
+    }
+    setShoeSaving(true);
+    setShoeError(null);
+    setShoeSuccess(null);
+    try {
+      const initialMileageM = shoeMileageInput
+        ? convertToMeters(parseFloat(shoeMileageInput), unitPreference)
+        : null;
+      const shoe = await createShoe({
+        brand: shoeBrand.trim(),
+        model: shoeModel.trim(),
+        initialMileageM,
+      });
+      await setDefaultShoe(shoe.id);
+      setShoeSuccess(`${shoe.brand} ${shoe.model} saved as your default shoe.`);
+      setShoeBrand('');
+      setShoeModel('');
+      setShoeMileageInput('');
+    } catch (error) {
+      setShoeError(error instanceof Error ? error.message : 'Failed to create shoe');
+    } finally {
+      setShoeSaving(false);
+    }
+  };
+
+  const handleContinue = async () => {
+    setContinueError(null);
+    setIsContinuing(true);
+    try {
+      await updateUnitPreference(unitPreference);
+      setUnitsSaved(true);
+      if (!hrSaved) {
+        setContinueError('Save heart rate zones before continuing.');
+        setIsContinuing(false);
+        return;
+      }
+      onContinue();
+    } catch (error) {
+      setContinueError(error instanceof Error ? error.message : 'Failed to save settings');
+      setIsContinuing(false);
+    }
+  };
+
+  const canContinue = unitsSaved && hrSaved && !isContinuing;
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <Card className="space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold text-ink">Unit preference</h2>
+          <p className="mt-1 text-sm text-muted">
+            Choose how distances, paces, and elevations are shown. New imports use this for split
+            boundaries.
+          </p>
+        </div>
+        <div className="flex gap-3">
+          <Button
+            type="button"
+            variant={unitPreference === 'metric' ? 'primary' : 'secondary'}
+            onClick={() => void selectUnit('metric')}
+          >
+            Metric
+          </Button>
+          <Button
+            type="button"
+            variant={unitPreference === 'imperial' ? 'primary' : 'secondary'}
+            onClick={() => void selectUnit('imperial')}
+          >
+            Imperial
+          </Button>
+        </div>
+        <div className="bg-canvas p-4 rounded-tempo border border-border">
+          <h3 className="text-sm font-semibold text-ink mb-3">Preview</h3>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+            <div>
+              <div className="text-muted mb-1">Distance</div>
+              <div className="text-ink font-medium">
+                {formatDistance(10000, unitPreference)}
+              </div>
+            </div>
+            <div>
+              <div className="text-muted mb-1">Pace</div>
+              <div className="text-ink font-medium">{formatPace(300, unitPreference)}</div>
+            </div>
+            <div>
+              <div className="text-muted mb-1">Elevation</div>
+              <div className="text-ink font-medium">
+                {formatElevation(150, unitPreference)}
+              </div>
+            </div>
+          </div>
+        </div>
+        {unitsSaved ? (
+          <p className="text-sm text-ink">Unit preference saved.</p>
+        ) : (
+          <p className="text-sm text-muted">Select metric or imperial to continue.</p>
+        )}
+      </Card>
+
+      <Card className="space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold text-ink">Heart rate zones</h2>
+          <p className="mt-1 text-sm text-muted">
+            Configure zones before importing so relative effort can be calculated on intake.
+          </p>
+        </div>
+
+        {isLoadingHr ? (
+          <p className="text-sm text-muted">Loading…</p>
+        ) : (
+          <>
+            <div>
+              <label className="block text-sm font-medium text-ink mb-3">
+                Calculation method
+              </label>
+              <div className="space-y-2">
+                {(
+                  [
+                    ['AgeBased', '220 − Age (Default)'],
+                    ['Karvonen', 'Karvonen (Heart Rate Reserve)'],
+                    ['Custom', 'Custom Zones'],
+                  ] as const
+                ).map(([value, label]) => (
+                  <label key={value} className="flex items-center">
+                    <input
+                      type="radio"
+                      name="onboardingCalculationMethod"
+                      value={value}
+                      checked={calculationMethod === value}
+                      onChange={(e) => {
+                        setCalculationMethod(e.target.value as HeartRateCalculationMethod);
+                        setHrSaved(false);
+                      }}
+                      className="mr-2 h-4 w-4 accent-[var(--volt)]"
+                    />
+                    <span className="text-sm text-ink">{label}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            {calculationMethod === 'AgeBased' && (
+              <div>
+                <label className="block text-sm font-medium text-ink mb-2">Age</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={120}
+                  value={age}
+                  onChange={(e) => {
+                    setAge(parseInt(e.target.value, 10) || 30);
+                    setHrSaved(false);
+                  }}
+                  className={fieldClass}
+                />
+                <p className="text-xs text-muted mt-1">
+                  Max HR will be calculated as 220 − age = {220 - age} BPM
+                </p>
+              </div>
+            )}
+
+            {calculationMethod === 'Karvonen' && (
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-ink mb-2">
+                    Resting heart rate (BPM)
+                  </label>
+                  <input
+                    type="number"
+                    min={30}
+                    max={120}
+                    value={restingHr}
+                    onChange={(e) => {
+                      setRestingHr(parseInt(e.target.value, 10) || 60);
+                      setHrSaved(false);
+                    }}
+                    className={fieldClass}
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-ink mb-2">
+                    Maximum heart rate (BPM)
+                  </label>
+                  <input
+                    type="number"
+                    min={60}
+                    max={250}
+                    value={maxHr}
+                    onChange={(e) => {
+                      setMaxHr(parseInt(e.target.value, 10) || 190);
+                      setHrSaved(false);
+                    }}
+                    className={fieldClass}
+                  />
+                  <p className="text-xs text-muted mt-1">
+                    Heart rate reserve = {maxHr} − {restingHr} = {maxHr - restingHr} BPM
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {calculationMethod === 'Custom' && (
+              <div>
+                <label className="block text-sm font-medium text-ink mb-3">
+                  Custom zone boundaries (BPM)
+                </label>
+                <div className="space-y-3">
+                  {customZones.map((zone, index) => (
+                    <div key={index} className="flex items-center gap-3">
+                      <span className="text-sm font-medium text-ink w-16">Zone {index + 1}:</span>
+                      <input
+                        type="number"
+                        min={30}
+                        max={250}
+                        value={zone.min}
+                        onChange={(e) => {
+                          updateCustomZone(index, 'min', parseInt(e.target.value, 10) || 0);
+                          setHrSaved(false);
+                        }}
+                        className={`w-24 ${fieldClass}`}
+                        placeholder="Min"
+                      />
+                      <span className="text-muted">–</span>
+                      <input
+                        type="number"
+                        min={30}
+                        max={250}
+                        value={zone.max}
+                        onChange={(e) => {
+                          updateCustomZone(index, 'max', parseInt(e.target.value, 10) || 0);
+                          setHrSaved(false);
+                        }}
+                        className={`w-24 ${fieldClass}`}
+                        placeholder="Max"
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="bg-canvas border border-border p-4 rounded-tempo">
+              <h3 className="text-sm font-semibold text-ink mb-3">Zone preview</h3>
+              <div className="space-y-2">
+                {displayZones.map((zone, index) => (
+                  <div key={index} className="flex items-center justify-between text-sm">
+                    <span className="text-ink font-medium">Zone {index + 1}</span>
+                    <span className="text-muted">
+                      {zone.min} – {zone.max} BPM
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <Button onClick={() => void handleSaveHrZones()} disabled={isSavingHr}>
+                {isSavingHr ? 'Saving…' : 'Save heart rate zones'}
+              </Button>
+              {hrSaved ? <span className="text-sm text-ink">Zones saved.</span> : null}
+              {hrError ? (
+                <span className="text-sm text-danger" role="alert">
+                  {hrError}
+                </span>
+              ) : null}
+            </div>
+          </>
+        )}
+      </Card>
+
+      <Card className="space-y-3">
+        <button
+          type="button"
+          className="flex w-full items-center justify-between text-left"
+          onClick={() => setShoeOpen((open) => !open)}
+          aria-expanded={shoeOpen}
+        >
+          <div>
+            <h2 className="text-lg font-semibold text-ink">Add a default shoe</h2>
+            <p className="mt-1 text-sm text-muted">Optional — skip if you do not care yet.</p>
+          </div>
+          <span className="text-sm text-muted">{shoeOpen ? 'Hide' : 'Show'}</span>
+        </button>
+
+        {shoeOpen ? (
+          <div className="space-y-3 border-t border-border pt-4">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <label className="block text-sm font-medium text-ink mb-2">Brand</label>
+                <input
+                  type="text"
+                  value={shoeBrand}
+                  onChange={(e) => setShoeBrand(e.target.value)}
+                  className={fieldClass}
+                  placeholder="e.g. Nike"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-ink mb-2">Model</label>
+                <input
+                  type="text"
+                  value={shoeModel}
+                  onChange={(e) => setShoeModel(e.target.value)}
+                  className={fieldClass}
+                  placeholder="e.g. Pegasus 40"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-ink mb-2">
+                Initial mileage ({unitPreference === 'imperial' ? 'miles' : 'km'}, optional)
+              </label>
+              <input
+                type="number"
+                min={0}
+                step="0.1"
+                value={shoeMileageInput}
+                onChange={(e) => setShoeMileageInput(e.target.value)}
+                className={fieldClass}
+                placeholder={unitPreference === 'imperial' ? 'Miles already on shoe' : 'Kilometers already on shoe'}
+              />
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                type="button"
+                onClick={() => void handleCreateShoe()}
+                disabled={shoeSaving}
+              >
+                {shoeSaving ? 'Saving…' : 'Create and set as default'}
+              </Button>
+              {shoeSuccess ? <span className="text-sm text-ink">{shoeSuccess}</span> : null}
+              {shoeError ? (
+                <span className="text-sm text-danger" role="alert">
+                  {shoeError}
+                </span>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </Card>
+
+      <div className="flex flex-col gap-2">
+        <Button onClick={() => void handleContinue()} disabled={!canContinue}>
+          {isContinuing ? 'Continuing…' : 'Continue'}
+        </Button>
+        {!unitsSaved || !hrSaved ? (
+          <p className="text-sm text-muted">
+            Save unit preference and heart rate zones to continue.
+          </p>
+        ) : null}
+        {continueError ? (
+          <p className="text-sm text-danger" role="alert">
+            {continueError}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/onboarding/EssentialsStep.tsx
+++ b/frontend/components/onboarding/EssentialsStep.tsx
@@ -165,7 +165,7 @@ export function EssentialsStep({ onContinue }: EssentialsStepProps) {
   const canContinue = unitsSaved && hrSaved && !isContinuing;
 
   return (
-    <div className="space-y-6 max-w-2xl">
+    <div className="w-full space-y-6">
       <Card className="space-y-4">
         <div>
           <h2 className="text-lg font-semibold text-ink">Unit preference</h2>

--- a/frontend/components/ui/PageShell.tsx
+++ b/frontend/components/ui/PageShell.tsx
@@ -12,14 +12,34 @@ export function PageShell({
   subtitle,
   density = 'control',
   leading,
+  centered = false,
   children,
 }: {
   title: string;
   subtitle?: string;
   density?: Density;
   leading?: ReactNode;
+  /** Horizontally (and vertically) center content — auth / onboarding screens. */
+  centered?: boolean;
   children: ReactNode;
 }) {
+  if (centered) {
+    return (
+      <div className="flex min-h-[calc(100vh-4rem)] flex-col bg-canvas text-ink">
+        <main className="mx-auto flex w-full max-w-4xl flex-1 flex-col items-center justify-center px-6 py-8">
+          {leading ? <div className="mb-3 w-full max-w-md">{leading}</div> : null}
+          <header className="mb-6 w-full max-w-md text-center">
+            <h1 className="text-2xl font-bold text-ink">{title}</h1>
+            {subtitle ? (
+              <p className="mt-1 text-sm text-muted">{subtitle}</p>
+            ) : null}
+          </header>
+          <div className="flex w-full flex-col items-center">{children}</div>
+        </main>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-canvas text-ink">
       <main className={densityInner[density]}>

--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -9,6 +9,7 @@ interface User {
   username: string;
   createdAt: string;
   lastLoginAt: string | null;
+  onboardingCompleted: boolean;
 }
 
 interface AuthContextType {
@@ -19,9 +20,14 @@ interface AuthContextType {
   logout: () => Promise<void>;
   register: (username: string, password: string) => Promise<void>;
   checkAuth: () => Promise<void>;
+  completeOnboarding: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+function postAuthPath(user: User): string {
+  return user.onboardingCompleted ? '/dashboard' : '/onboarding';
+}
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
@@ -61,8 +67,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const login = async (username: string, password: string, rememberMe?: boolean) => {
     try {
       await api.login(username, password, rememberMe);
-      await checkAuth();
-      router.push('/dashboard');
+      const userInfo = await api.getCurrentUser();
+      setUser(userInfo);
+      setIsLoading(false);
+      router.push(postAuthPath(userInfo));
     } catch (error) {
       throw error;
     }
@@ -90,6 +98,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   };
 
+  const completeOnboarding = async () => {
+    const userInfo = await api.completeOnboarding();
+    setUser(userInfo);
+    router.push('/dashboard');
+  };
+
   const value: AuthContextType = {
     user,
     isAuthenticated: !!user,
@@ -98,6 +112,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     logout,
     register,
     checkAuth,
+    completeOnboarding,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
@@ -110,4 +125,3 @@ export function useAuth() {
   }
   return context;
 }
-

--- a/frontend/hooks/useImportJobSession.ts
+++ b/frontend/hooks/useImportJobSession.ts
@@ -27,18 +27,24 @@ function persistJobHint(id: string | null) {
 
 function otherKindBanner(kind: ImportJobKind): string {
   if (kind === 'tempo_export') {
-    return 'A Strava import is already running on the Import page. Finish or cancel it before restoring a Tempo export.';
+    return 'A Strava import is already in progress. Finish or cancel it before restoring a Tempo export.';
   }
-  return 'A Tempo export restore is already running in Settings. Finish or cancel it before starting a Strava import.';
+  return 'A Tempo export restore is already in progress. Finish or cancel it before starting a Strava import.';
 }
 
 export type UseImportJobSessionOptions = {
   kind: ImportJobKind;
   unitPreference?: 'metric' | 'imperial';
   onCompleted: (job: ImportJob) => void | Promise<void>;
+  onFailed?: (message: string) => void;
 };
 
-export function useImportJobSession({ kind, unitPreference, onCompleted }: UseImportJobSessionOptions) {
+export function useImportJobSession({
+  kind,
+  unitPreference,
+  onCompleted,
+  onFailed,
+}: UseImportJobSessionOptions) {
   const [jobId, setJobId] = useState<string | null>(null);
   const [uploadBytes, setUploadBytes] = useState<{ received: number; size: number } | null>(null);
   const [jobError, setJobError] = useState<string | null>(null);
@@ -93,7 +99,9 @@ export function useImportJobSession({ kind, unitPreference, onCompleted }: UseIm
           await onCompleted(hinted);
           persistJobHint(null);
         } else if (hinted.status === 'failed') {
-          setJobError(hinted.errorMessage || 'Import failed');
+          const message = hinted.errorMessage || 'Import failed';
+          setJobError(message);
+          onFailed?.(message);
           persistJobHint(null);
         } else {
           attachJob(hinted.id);
@@ -105,7 +113,7 @@ export function useImportJobSession({ kind, unitPreference, onCompleted }: UseIm
     return () => {
       cancelled = true;
     };
-  }, [attachJob, kind, onCompleted]);
+  }, [attachJob, kind, onCompleted, onFailed]);
 
   const { data: job } = useQuery({
     queryKey: ['import-job', kind, jobId],
@@ -136,12 +144,14 @@ export function useImportJobSession({ kind, unitPreference, onCompleted }: UseIm
         setJobError(null);
         void onCompleted(terminal);
       } else {
-        setJobError(terminal.errorMessage || 'Import failed');
+        const message = terminal.errorMessage || 'Import failed';
+        setJobError(message);
         clearWorkingState();
+        onFailed?.(message);
       }
     }, 0);
     return () => window.clearTimeout(timer);
-  }, [job, onCompleted, clearWorkingState]);
+  }, [job, onCompleted, onFailed, clearWorkingState]);
 
   const uploadMutation = useMutation({
     mutationFn: (file: File) => {
@@ -173,17 +183,21 @@ export function useImportJobSession({ kind, unitPreference, onCompleted }: UseIm
         return;
       }
       setJobError(error.message);
+      onFailed?.(error.message);
     },
   });
 
   const cancelMutation = useMutation({
     mutationFn: (id: string) => cancelImportJob(id),
     onSuccess: (cancelled: ImportJob) => {
-      setJobError(cancelled.errorMessage || 'cancelled');
+      const message = cancelled.errorMessage || 'cancelled';
+      setJobError(message);
       clearWorkingState();
+      onFailed?.(message);
     },
     onError: (error: Error) => {
       setJobError(error.message);
+      onFailed?.(error.message);
     },
   });
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -525,6 +525,11 @@ export function importJobToExportImportResponse(job: ImportJob): ExportImportRes
   };
 }
 
+/** True when a tempo_export job imported UserSettings (units / HR zones). */
+export function importJobHasSettings(job: ImportJob): boolean {
+  return (job.statistics?.settings?.imported ?? 0) > 0;
+}
+
 export async function exportAllData(): Promise<Blob> {
   const response = await fetchWithAuth(`${API_BASE_URL}/workouts/export`, {
     method: 'POST',

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -88,6 +88,7 @@ export interface UserInfo {
   username: string;
   createdAt: string;
   lastLoginAt: string | null;
+  onboardingCompleted: boolean;
 }
 
 export interface RegistrationAvailableResponse {
@@ -1417,6 +1418,24 @@ export async function getCurrentUser(): Promise<UserInfo> {
 
   if (!response.ok) {
     throw new Error(`Failed to get current user: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+export async function completeOnboarding(): Promise<UserInfo> {
+  const response = await fetchWithAuth(`${API_BASE_URL}/auth/onboarding/complete`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+  });
+
+  if (response.status === 401) {
+    throw new Error('Not authenticated');
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to complete onboarding: ${response.status}`);
   }
 
   return response.json();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
   - Getting Started:
     - getting-started/index.md
     - getting-started/quick-start.md
+    - getting-started/onboarding.md
     - getting-started/installation.md
     - getting-started/configuration.md
   - User Guide:


### PR DESCRIPTION
## Summary
- Hard-gated first-run onboarding after registration: optional Tempo export restore, essentials (units + HR zones, optional default shoe), optional Strava archive — driven by `User.OnboardingCompleted` (`GET /auth/me`, `POST /auth/onboarding/complete`; existing users backfilled completed)
- Import page is GPX/FIT only; Strava bulk and Tempo restore live under Settings → **Migrate / restore** (same ImportJob rails; Bruno/curl adapters unchanged)
- Docs and OpenAPI updated for the wizard, file-only Import, and migrate/restore homes

## Test plan
- [ ] Fresh register → lands on `/onboarding`; Dashboard/Import/Settings redirect until complete; logout works from onboarding shell
- [ ] Restore Yes → successful Tempo ZIP with settings completes and opens dashboard; without settings continues to essentials; fail/cancel offers retry and “Set up fresh”
- [ ] Essentials require units + HR zones; optional shoe; Strava No finishes setup; Strava Yes runs job with unit preference; fail/cancel offers retry and “Skip for now”
- [ ] After complete: Import has no Strava ZIP UI; Settings Export visible; Migrate / restore has Strava + Tempo restore; Data Recalculation still separate
- [ ] Upgrade path: existing user is not forced through onboarding
- [ ] Auth tests / Bruno: `POST /auth/onboarding/complete` idempotent; `GET /auth/me` includes `onboardingCompleted`