### PR TITLE
feat: add CARTO basemaps API key support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CARTO basemaps API key** - Optional `CartoBasemaps:ApiKey` / `CartoBasemaps__ApiKey` on the API (Docker: `CARTO_BASEMAPS_API_KEY` in `.env`). Authenticated `GET /settings/carto-basemaps` exposes the key to the command center; workout maps append `?key=` to CARTO raster tile URLs.
+
 ## [2.7.0] - 2026-08-19
 
 ### Added

--- a/api/Endpoints/SettingsEndpoints.cs
+++ b/api/Endpoints/SettingsEndpoints.cs
@@ -349,6 +349,24 @@ public static class SettingsEndpoints
     }
 
     /// <summary>
+    /// Get CARTO basemaps configuration for the command center
+    /// </summary>
+    /// <param name="cartoBasemaps">CARTO basemaps configuration</param>
+    /// <returns>API key when configured, otherwise null</returns>
+    /// <remarks>
+    /// Returns the operator-configured CARTO basemaps API key from environment configuration.
+    /// When not set, map tiles are served without a key (watermarked by CARTO).
+    /// </remarks>
+    private static IResult GetCartoBasemaps(CartoBasemapsConfig cartoBasemaps)
+    {
+        var apiKey = string.IsNullOrWhiteSpace(cartoBasemaps.ApiKey)
+            ? null
+            : cartoBasemaps.ApiKey.Trim();
+
+        return Results.Ok(new { apiKey });
+    }
+
+    /// <summary>
     /// Get unit preference
     /// </summary>
     /// <param name="db">Database context</param>
@@ -460,6 +478,12 @@ public static class SettingsEndpoints
             .Produces(400)
             .WithSummary("Update unit preference")
             .WithDescription("Updates the unit preference (metric or imperial)");
+
+        group.MapGet("/carto-basemaps", GetCartoBasemaps)
+            .WithName("GetCartoBasemaps")
+            .Produces(200)
+            .WithSummary("Get CARTO basemaps configuration")
+            .WithDescription("Returns the operator-configured CARTO basemaps API key from environment configuration. When not set, map tiles are served without a key.");
 
         group.MapGet("/default-shoe", GetDefaultShoe)
             .WithName("GetDefaultShoe")

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -187,6 +187,12 @@ builder.Services.AddSingleton(new ElevationCalculationConfig
     MinDistanceMeters = builder.Configuration.GetValue<double>("ElevationCalculation:MinDistanceMeters", 10.0)
 });
 
+// Configure CARTO basemaps (optional; missing key serves watermarked tiles)
+builder.Services.AddSingleton(new CartoBasemapsConfig
+{
+    ApiKey = builder.Configuration["CartoBasemaps:ApiKey"]?.Trim() ?? string.Empty
+});
+
 // Configure form options for large file uploads (bulk import)
 builder.Services.Configure<Microsoft.AspNetCore.Http.Features.FormOptions>(options =>
 {

--- a/api/Services/CartoBasemapsConfig.cs
+++ b/api/Services/CartoBasemapsConfig.cs
@@ -1,0 +1,6 @@
+namespace Tempo.Api.Services;
+
+public class CartoBasemapsConfig
+{
+    public string ApiKey { get; set; } = string.Empty;
+}

--- a/api/Services/ImportJobService.cs
+++ b/api/Services/ImportJobService.cs
@@ -232,10 +232,9 @@ public class ImportJobService
             return ImportJobHttpResult.Fail(StatusCodes.Status400BadRequest, "Job cannot be cancelled");
         }
 
-        job.CancelRequested = true;
-
         if (job.Status is ImportJobStatuses.Receiving or ImportJobStatuses.Queued)
         {
+            job.CancelRequested = true;
             FailCancelled(job);
             await _db.SaveChangesAsync();
             DeleteJobDirectory(job.Id);
@@ -244,7 +243,17 @@ public class ImportJobService
         }
         else
         {
-            await _db.SaveChangesAsync();
+            var updated = await _db.ImportJobs
+                .Where(row => row.Id == id && row.Status == ImportJobStatuses.Running)
+                .ExecuteUpdateAsync(setters => setters
+                    .SetProperty(row => row.CancelRequested, true));
+
+            if (updated == 0)
+            {
+                return ImportJobHttpResult.Fail(StatusCodes.Status400BadRequest, "Job cannot be cancelled");
+            }
+
+            await _db.Entry(job).ReloadAsync();
         }
 
         return ImportJobHttpResult.Json(StatusCodes.Status200OK, job);

--- a/api/Services/ImportJobWorker.cs
+++ b/api/Services/ImportJobWorker.cs
@@ -127,7 +127,7 @@ public class ImportJobWorker : BackgroundService
                 }
 
                 ApplyStravaProgress(completed, result);
-                if (completed.CancelRequested)
+                if (await IsCancelRequestedAsync(db, jobId))
                 {
                     await FailJobAsync(db, completed, ImportJobErrorMessages.Cancelled, logger);
                     return;
@@ -151,7 +151,7 @@ public class ImportJobWorker : BackgroundService
 
                 ApplyTempoProgressFromResult(completed, result, completed.Total);
 
-                if (completed.CancelRequested)
+                if (await IsCancelRequestedAsync(db, jobId))
                 {
                     await FailJobAsync(db, completed, ImportJobErrorMessages.Cancelled, logger);
                     return;
@@ -209,14 +209,36 @@ public class ImportJobWorker : BackgroundService
         }
     }
 
+    private static async Task<bool> IsCancelRequestedAsync(TempoDbContext db, Guid jobId) =>
+        await db.ImportJobs
+            .AsNoTracking()
+            .Where(row => row.Id == jobId)
+            .Select(row => row.CancelRequested)
+            .SingleAsync(CancellationToken.None);
+
     private static async Task CompleteJobAsync(TempoDbContext db, ImportJob job, ILogger logger)
     {
         var archivePath = job.ArchivePath;
 
+        // Read cancel state from the database so a concurrent cancel is not clobbered
+        // when persisting final counters from the tracked entity.
+        if (await IsCancelRequestedAsync(db, job.Id))
+        {
+            await FailJobAsync(db, job, ImportJobErrorMessages.Cancelled, logger);
+            return;
+        }
+
         // Persist final counters/results first, then only mark the job completed if no
         // concurrent cancel request has landed. This avoids a race where a late cancel
         // can be overwritten by the final completed write.
+        db.Entry(job).Property(row => row.CancelRequested).IsModified = false;
         await db.SaveChangesAsync(CancellationToken.None);
+
+        if (await IsCancelRequestedAsync(db, job.Id))
+        {
+            await FailJobAsync(db, job, ImportJobErrorMessages.Cancelled, logger);
+            return;
+        }
 
         var finishedAt = DateTime.UtcNow;
         var updated = await db.ImportJobs

--- a/api/Tempo.Api.Tests/IntegrationTests/ImportJobTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/ImportJobTests.cs
@@ -664,26 +664,31 @@ public class ImportJobTests : IClassFixture<TempoWebApplicationFactory>
 
         var deadline = DateTime.UtcNow.AddSeconds(30);
         ImportJobDocument? snapshot = null;
+        var cancelSent = false;
         while (DateTime.UtcNow < deadline)
         {
             var poll = await client.GetAsync($"/workouts/import/jobs/{started!.Id}");
             snapshot = await poll.Content.ReadFromJsonAsync<ImportJobDocument>(JsonOptions);
-            if (snapshot!.Processed >= 3 && snapshot.Status == ImportJobStatuses.Running)
+            if (snapshot!.Status is ImportJobStatuses.Completed or ImportJobStatuses.Failed)
             {
                 break;
             }
-            if (snapshot.Status is ImportJobStatuses.Completed or ImportJobStatuses.Failed)
+
+            if (!cancelSent &&
+                snapshot.Processed >= 3 &&
+                snapshot.Status == ImportJobStatuses.Running)
             {
-                break;
+                (await client.DeleteAsync($"/workouts/import/jobs/{started!.Id}")).StatusCode.Should().Be(HttpStatusCode.OK);
+                cancelSent = true;
             }
+
             await Task.Delay(20);
         }
 
         snapshot.Should().NotBeNull();
-        if (snapshot!.Status is ImportJobStatuses.Queued or ImportJobStatuses.Running or ImportJobStatuses.Receiving)
+        if (cancelSent)
         {
-            (await client.DeleteAsync($"/workouts/import/jobs/{started!.Id}")).StatusCode.Should().Be(HttpStatusCode.OK);
-            var finished = await PollUntilTerminalAsync(client, started.Id);
+            var finished = await PollUntilTerminalAsync(client, started!.Id);
             finished.Status.Should().Be(ImportJobStatuses.Failed);
             finished.ErrorMessage.Should().Be(ImportJobErrorMessages.Cancelled);
         }

--- a/api/Tempo.Api.Tests/IntegrationTests/SettingsEndpointsTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/SettingsEndpointsTests.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Tempo.Api.Data;
 using Tempo.Api.Models;
+using Tempo.Api.Services;
 using Tempo.Api.Tests.Infrastructure;
 using Xunit;
 
@@ -651,6 +652,70 @@ public class SettingsEndpointsTests : IClassFixture<TempoWebApplicationFactory>
 
     #endregion
 
+    #region GetCartoBasemaps Tests
+
+    [Fact]
+    public async Task GetCartoBasemaps_WithoutAuthentication_ReturnsUnauthorized()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/settings/carto-basemaps");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetCartoBasemaps_WithNoConfiguredKey_ReturnsNullApiKey()
+    {
+        // Arrange
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        // Act
+        var response = await client.GetAsync("/settings/carto-basemaps");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<CartoBasemapsResponse>();
+        result.Should().NotBeNull();
+        result!.ApiKey.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetCartoBasemaps_WithConfiguredKey_ReturnsApiKey()
+    {
+        // Arrange
+        using var factoryWithCartoKey = new TempoWebApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    var descriptor = services.SingleOrDefault(s => s.ServiceType == typeof(CartoBasemapsConfig));
+                    if (descriptor != null)
+                    {
+                        services.Remove(descriptor);
+                    }
+
+                    services.AddSingleton(new CartoBasemapsConfig { ApiKey = "test-carto-key" });
+                });
+            });
+
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(factoryWithCartoKey);
+
+        // Act
+        var response = await client.GetAsync("/settings/carto-basemaps");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<CartoBasemapsResponse>();
+        result.Should().NotBeNull();
+        result!.ApiKey.Should().Be("test-carto-key");
+    }
+
+    #endregion
+
     #region Response Models
 
     private class HeartRateZonesResponse
@@ -694,6 +759,11 @@ public class SettingsEndpointsTests : IClassFixture<TempoWebApplicationFactory>
     private class ErrorResponse
     {
         public string Error { get; set; } = string.Empty;
+    }
+
+    private class CartoBasemapsResponse
+    {
+        public string? ApiKey { get; set; }
     }
 
     #endregion

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -17,6 +17,9 @@
     "NoiseThresholdMeters": 2.0,
     "MinDistanceMeters": 10.0
   },
+  "CartoBasemaps": {
+    "ApiKey": ""
+  },
   "JWT": {
     "SecretKey": "CHANGE_THIS_IN_PRODUCTION_USE_ENVIRONMENT_VARIABLE",
     "Issuer": "Tempo",

--- a/api/bruno/Tempo.Api/Settings/Get CARTO basemaps configuration.bru
+++ b/api/bruno/Tempo.Api/Settings/Get CARTO basemaps configuration.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Get CARTO basemaps configuration
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{baseUrl}}/settings/carto-basemaps
+  body: none
+  auth: inherit
+}
+
+example {
+  name: 200 Response
+  description: OK
+  
+  request: {
+    url: {{baseUrl}}/settings/carto-basemaps
+    method: GET
+    mode: none
+  }
+  
+  response: {
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -48,6 +48,8 @@ services:
       JWT__Audience: "Tempo"
       JWT__ExpirationDays: "7"
       JWT__RememberMeExpirationDays: "30"
+      # CARTO basemaps (optional; set CARTO_BASEMAPS_API_KEY in .env)
+      CartoBasemaps__ApiKey: "${CARTO_BASEMAPS_API_KEY:-}"
     ports:
       - "5001:5001"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       # CORS
       CORS__AllowedOrigins: "http://localhost:3000"
       JWT__SecretKey: "UXRYmMMI1s3Wmrfeno2RKQCuA98eu3gfcq5sjNm+0w0="
+      # CARTO basemaps (optional; set CARTO_BASEMAPS_API_KEY in .env)
+      CartoBasemaps__ApiKey: "${CARTO_BASEMAPS_API_KEY:-}"
     ports:
       - "5001:5001"
     volumes:

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -38,6 +38,7 @@ Edit `docker-compose.prod.yml` or use environment variables:
 **Recommended:**
 - `ConnectionStrings__DefaultConnection` - Database connection string
 - `CORS__AllowedOrigins` - Comma-separated list of allowed origins
+- `CARTO_BASEMAPS_API_KEY` - Free [CARTO basemaps API key](https://carto.com/basemaps/apikey) (set in `.env`; removes map watermark)
 - Database password (change from default)
 
 ### 3. Start Services

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -63,6 +63,16 @@ ElevationCalculation__NoiseThresholdMeters: "2.0"
 ElevationCalculation__MinDistanceMeters: "10.0"
 ```
 
+### CARTO Basemaps (Maps)
+
+Workout maps require a free CARTO API key. Set in `.env` (gitignored):
+
+```bash
+CARTO_BASEMAPS_API_KEY=your-key-here
+```
+
+Compose passes this to the API as `CartoBasemaps__ApiKey`. Request a key at [carto.com/basemaps/apikey](https://carto.com/basemaps/apikey). Restart the API and hard-refresh the browser after updating.
+
 ### JWT Configuration
 
 ```yaml
@@ -88,6 +98,7 @@ JWT__ExpirationDays: "7"
 - [ ] Environment variables set correctly
 - [ ] Database connection string configured
 - [ ] Media storage path configured and writable
+- [ ] CARTO basemaps API key set (`CARTO_BASEMAPS_API_KEY` in `.env`) if maps should not show the watermark
 - [ ] Ports configured appropriately
 - [ ] Health checks enabled
 

--- a/docs/developers/architecture.md
+++ b/docs/developers/architecture.md
@@ -13,7 +13,7 @@ Tempo is a self-hosted running tracker built as a full-stack application with a 
 - **Appearance**: Dark-first. Tailwind `class` strategy on `<html>` (`dark`). Preference is `system` | `dark` | `light` in `localStorage` (`tempo-appearance`); not UserSettings. See `frontend/lib/appearance.ts`.
 - **Icons**: Tabler Icons (`@tabler/icons-react`) for UI icons. Brand marks live in `frontend/public/` (`tempo-mark-volt.png`, `tempo-mark-ink.png`).
 - **State Management**: TanStack Query for server state
-- **Maps**: Leaflet/React-Leaflet. Carto Dark Matter in Dark appearance, Voyager in Light; polyline and Highlight from tokens; OSM + CARTO attribution (no OSM-only fallback).
+- **Maps**: Leaflet/React-Leaflet. Carto Dark Matter in Dark appearance, Voyager in Light; polyline and Highlight from tokens; OSM + CARTO attribution. Operators configure a CARTO basemaps API key via `CartoBasemaps:ApiKey` / `CartoBasemaps__ApiKey` on the API; the command center reads it from `GET /settings/carto-basemaps`.
 - **Charts**: Recharts; series colors from identity tokens. Workout overview charts HR, pace, and elevation via `getWorkoutTimeSeries` in `frontend/lib/api.ts` (pages until complete or 20,000 samples).
 - **Highlight**: Shared overview focus (`splitIdx` and/or `elapsedSeconds`) in `frontend/lib/workoutHighlight.ts` — map, splits, and charts follow together.
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -118,6 +118,44 @@ environment:
 - Change the default database password in production
 - Store the JWT secret key securely (environment variables, secrets manager, etc.)
 
+## CARTO Basemaps (Maps)
+
+Workout maps use CARTO raster tiles (Dark Matter / Voyager). CARTO now requires a free API key; without one, tiles show an "API key required" watermark.
+
+1. Request a key at [carto.com/basemaps/apikey](https://carto.com/basemaps/apikey) (free within CARTO's fair use limit; no CARTO account required).
+2. Configure the key on the **API** service (not the frontend). Do not commit the key to git.
+
+### Docker
+
+Add to a gitignored `.env` file in your deployment directory:
+
+```bash
+CARTO_BASEMAPS_API_KEY=your-key-here
+```
+
+Both `docker-compose.yml` and `docker-compose.prod.yml` pass this to the API as `CartoBasemaps__ApiKey`. Restart the API after changing the key.
+
+### Local development
+
+Set the environment variable before starting the API:
+
+```bash
+export CARTO_BASEMAPS_API_KEY=your-key-here
+cd api && dotnet watch run
+```
+
+Or add to `api/appsettings.Development.json` (local only; do not commit real keys):
+
+```json
+{
+  "CartoBasemaps": {
+    "ApiKey": "your-key-here"
+  }
+}
+```
+
+After configuring, hard-refresh the browser — CARTO and your browser may cache watermarked tiles briefly.
+
 ## Environment Variables Reference
 
 All configuration can be set via environment variables using the double underscore (`__`) notation for nested keys:
@@ -129,6 +167,7 @@ All configuration can be set via environment variables using the double undersco
 | `MediaStorage:MaxFileSizeBytes` | `MediaStorage__MaxFileSizeBytes` | `52428800` |
 | `ElevationCalculation:NoiseThresholdMeters` | `ElevationCalculation__NoiseThresholdMeters` | `2.0` |
 | `ElevationCalculation:MinDistanceMeters` | `ElevationCalculation__MinDistanceMeters` | `10.0` |
+| `CartoBasemaps:ApiKey` | `CartoBasemaps__ApiKey` or `CARTO_BASEMAPS_API_KEY` (via compose `.env`) | empty (watermarked tiles) |
 | `CORS:AllowedOrigins` | `CORS__AllowedOrigins` | - |
 | `JWT:SecretKey` | `JWT__SecretKey` | - (REQUIRED in production) |
 | `JWT:Issuer` | `JWT__Issuer` | `Tempo` |

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -424,6 +424,26 @@
         ]
       }
     },
+    "/settings/carto-basemaps": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Get CARTO basemaps configuration for the command center",
+        "description": "Returns the operator-configured CARTO basemaps API key from environment configuration.\nWhen not set, map tiles are served without a key (watermarked by CARTO).",
+        "operationId": "GetCartoBasemaps",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [ ]
+          }
+        ]
+      }
+    },
     "/settings/default-shoe": {
       "get": {
         "tags": [

--- a/docs/user-guide/viewing-workouts.md
+++ b/docs/user-guide/viewing-workouts.md
@@ -52,6 +52,7 @@ Map, splits, and time-series charts share one **Highlight**: a split index and/o
 
 - **Interactive Route Map** - Visualize your route with Leaflet maps
 - **Themed tiles** - Dark Matter in Dark appearance, Voyager in Light (CARTO; attribution includes OpenStreetMap)
+- **CARTO API key** - CARTO now requires a free API key for basemap tiles. Without one, maps show an "API key required" watermark. Request a key at [carto.com/basemaps/apikey](https://carto.com/basemaps/apikey), set `CARTO_BASEMAPS_API_KEY` in your deployment `.env` (see [Configuration](../getting-started/configuration.md#carto-basemaps-maps)), restart the API, and hard-refresh the browser.
 - **Zoom and Pan** - Explore different parts of your route
 - Route stroke and Highlight colors follow the command-center identity (volt on dark; a dark stroke on light)
 

--- a/frontend/components/WorkoutMap.tsx
+++ b/frontend/components/WorkoutMap.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+import { getCartoBasemaps } from '@/lib/api';
+import { cartoTilesForAppearance } from '@/lib/cartoTiles';
 import {
   highlightFromRouteDistance,
   routeDistanceFromElapsed,
@@ -22,16 +25,6 @@ if (typeof window !== 'undefined') {
 
 const CARTO_ATTRIBUTION =
   '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>';
-
-const DARK_TILES = {
-  url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
-  attribution: CARTO_ATTRIBUTION,
-};
-
-const LIGHT_TILES = {
-  url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
-  attribution: CARTO_ATTRIBUTION,
-};
 
 const TILE_OPTIONS: L.TileLayerOptions = {
   attribution: CARTO_ATTRIBUTION,
@@ -273,6 +266,13 @@ export default function WorkoutMap({
   interactive = true,
 }: WorkoutMapProps) {
   const isDark = useDocumentDark();
+  const { data: cartoBasemaps, isPending: cartoBasemapsPending } = useQuery({
+    queryKey: ['carto-basemaps'],
+    queryFn: getCartoBasemaps,
+    staleTime: Infinity,
+    retry: 1,
+  });
+  const cartoApiKey = cartoBasemaps?.apiKey ?? null;
   // Ref to store the Leaflet map instance
   const mapRef = useRef<L.Map | null>(null);
   // Ref to container div element
@@ -338,6 +338,10 @@ export default function WorkoutMap({
 
   // Effect to create and manage the Leaflet map
   useEffect(() => {
+    if (cartoBasemapsPending) {
+      return;
+    }
+
     if (!containerRef.current || !route || leafletCoordinates.length === 0) {
       return;
     }
@@ -370,14 +374,11 @@ export default function WorkoutMap({
       keyboard: interactive,
     });
 
-    const tiles = document.documentElement.classList.contains('dark')
-      ? DARK_TILES
-      : LIGHT_TILES;
-    const tileLayer = L.tileLayer(tiles.url, TILE_OPTIONS).addTo(map);
+    const isDarkMode = document.documentElement.classList.contains('dark');
+    const tileUrl = cartoTilesForAppearance(isDarkMode, cartoApiKey);
+    const tileLayer = L.tileLayer(tileUrl, TILE_OPTIONS).addTo(map);
 
-    const { polyline: polylineColor } = mapStrokeColors(
-      document.documentElement.classList.contains('dark')
-    );
+    const { polyline: polylineColor } = mapStrokeColors(isDarkMode);
     const polyline = L.polyline(leafletCoordinates, {
       color: polylineColor,
       weight: 4,
@@ -495,11 +496,15 @@ export default function WorkoutMap({
         delete (container as any)._leaflet;
       }
     };
-  }, [workoutId, center, bounds, leafletCoordinates, route, interactive]);
+  }, [workoutId, center, bounds, leafletCoordinates, route, interactive, cartoBasemapsPending, cartoApiKey]);
 
   useEffect(() => {
-    const tiles = isDark ? DARK_TILES : LIGHT_TILES;
-    tileLayerRef.current?.setUrl(tiles.url);
+    if (cartoBasemapsPending) {
+      return;
+    }
+
+    const tileUrl = cartoTilesForAppearance(isDark, cartoApiKey);
+    tileLayerRef.current?.setUrl(tileUrl);
 
     const colors = mapStrokeColors(isDark);
     polylineRef.current?.setStyle({ color: colors.polyline });
@@ -508,7 +513,7 @@ export default function WorkoutMap({
       color: colors.highlight,
       fillColor: colors.highlight,
     });
-  }, [isDark]);
+  }, [isDark, cartoBasemapsPending, cartoApiKey]);
 
   // Effect to handle highlighted split segment
   useEffect(() => {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1244,6 +1244,20 @@ export async function recalculateAllRelativeEffort(): Promise<RecalculateRelativ
   return response.json();
 }
 
+export async function getCartoBasemaps(): Promise<{ apiKey: string | null }> {
+  const response = await fetchWithAuth(`${API_BASE_URL}/settings/carto-basemaps`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to get CARTO basemaps configuration: ${response.status}`);
+  }
+
+  return response.json();
+}
+
 export async function getUnitPreference(): Promise<{ unitPreference: 'metric' | 'imperial' }> {
   const response = await fetchWithAuth(`${API_BASE_URL}/settings/unit-preference`, {
     method: 'GET',

--- a/frontend/lib/cartoTiles.ts
+++ b/frontend/lib/cartoTiles.ts
@@ -1,0 +1,26 @@
+export const CARTO_DARK_TILE_URL =
+  'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+
+export const CARTO_LIGHT_TILE_URL =
+  'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png';
+
+export function cartoTileUrl(
+  baseUrl: string,
+  apiKey: string | null | undefined
+): string {
+  const trimmed = apiKey?.trim();
+  if (!trimmed) {
+    return baseUrl;
+  }
+
+  const separator = baseUrl.includes('?') ? '&' : '?';
+  return `${baseUrl}${separator}key=${encodeURIComponent(trimmed)}`;
+}
+
+export function cartoTilesForAppearance(
+  isDark: boolean,
+  apiKey: string | null | undefined
+): string {
+  const baseUrl = isDark ? CARTO_DARK_TILE_URL : CARTO_LIGHT_TILE_URL;
+  return cartoTileUrl(baseUrl, apiKey);
+}


### PR DESCRIPTION
- Introduced optional CARTO basemaps API key configuration via `CartoBasemaps:ApiKey` in the API and environment variable `CARTO_BASEMAPS_API_KEY`.
- Updated API endpoints to expose the configured API key for command center access.
- Enhanced documentation to guide users on obtaining and configuring the CARTO API key for seamless map integration.
- Implemented frontend adjustments to utilize the API key for fetching CARTO basemaps without watermarks.