### PR TITLE
feat: enhance workout intake with decoded workout support

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,7 +33,7 @@ In-process derive of elevation gain, `WorkoutRoute`, `WorkoutSplit`s, and `Worko
 _Avoid_: GpxParser splits, GPS smoothing (as the module name)
 
 **Workout intake**:
-The persist pipeline behind `POST /workouts/import` and Strava bulk per-file processing: parse, geometry, duplicate policy, weather, relative effort, best efforts. Not the HTTP module and not Settings ZIP restore.
+The persist pipeline behind `POST /workouts/import` and Strava bulk per-file processing: decode adapter (GPX/FIT) then `PersistAsync` (geometry, duplicate policy, weather, relative effort, best efforts). Persist is the single pipeline; new formats enter via decoded input, not a second pipeline. Not the HTTP module and not Settings ZIP restore.
 _Avoid_: import endpoint (when meaning this module), bulk persist
 
 **Import job**:

--- a/api/Services/WorkoutIntake.cs
+++ b/api/Services/WorkoutIntake.cs
@@ -23,7 +23,30 @@ public sealed class WorkoutIntakeResult
 }
 
 /// <summary>
-/// One Workout persist pipeline: parse, geometry, duplicate policy, weather, relative effort, best efforts.
+/// Decoded workout ready for the persist pipeline. Produced by file parsers today;
+/// HealthKit (and other adapters) can build this without a file stream.
+/// </summary>
+public sealed class DecodedWorkout
+{
+    public DateTime StartedAt { get; init; }
+    public int DurationS { get; init; }
+    public double DistanceM { get; init; }
+    public List<TrackPoint> TrackPoints { get; init; } = new();
+    /// <summary>
+    /// Null = GPX-style time series from TrackPoints; non-null = FIT series path.
+    /// </summary>
+    public IReadOnlyList<TrackPoint>? SeriesPoints { get; init; }
+    public string? Name { get; init; }
+    public string? RawGpxDataJson { get; init; }
+    public string? RawFitDataJson { get; init; }
+    public byte[]? RawFileData { get; init; }
+    public string? RawFileName { get; init; }
+    public string? RawFileType { get; init; }
+}
+
+/// <summary>
+/// Workout intake: file decode adapters feed PersistAsync (geometry, duplicate policy,
+/// weather, relative effort, best efforts). Persist is the single pipeline for all sources.
 /// </summary>
 public class WorkoutIntake
 {
@@ -59,6 +82,9 @@ public class WorkoutIntake
         _logger = logger;
     }
 
+    /// <summary>
+    /// File decode adapter: validate stream, parse GPX/FIT, then persist.
+    /// </summary>
     public async Task<WorkoutIntakeResult> ProcessAsync(
         Stream stream,
         string fileName,
@@ -81,7 +107,7 @@ public class WorkoutIntake
             return Error("File is empty");
         }
 
-        var (fileType, isGpx, isFitGz) = DetermineFileType(fileName);
+        var (fileType, _, isFitGz) = DetermineFileType(fileName);
         if (fileType == null)
         {
             return Error("File must be a GPX or FIT file (.gpx, .fit, or .fit.gz)");
@@ -90,51 +116,52 @@ public class WorkoutIntake
         try
         {
             var (parseResult, fitResult) = ParseWorkoutFile(rawFileData, fileType, isFitGz);
-            var (startTime, durationSeconds, distanceMeters, trackPoints, rawGpxDataJson, rawFitDataJson) =
-                ExtractParseResultData(parseResult, fitResult);
+            var decoded = ToDecodedWorkout(parseResult, fitResult, rawFileData, fileName, fileType);
+            return await PersistAsync(decoded, overlay);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "Error parsing workout file");
+            return Error(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error importing workout file");
+            return Error(ex.Message);
+        }
+    }
 
+    /// <summary>
+    /// Decode-agnostic persist pipeline: duplicate policy, geometry, weather, shoe,
+    /// relative effort, best efforts.
+    /// </summary>
+    public async Task<WorkoutIntakeResult> PersistAsync(
+        DecodedWorkout decoded,
+        WorkoutIntakeOverlay? overlay = null)
+    {
+        try
+        {
+            var startedAtUtc = ToUtc(decoded.StartedAt);
+            var distanceMeters = decoded.DistanceM;
+            var durationSeconds = decoded.DurationS;
+            var trackPoints = decoded.TrackPoints;
             var avgPaceS = distanceMeters > 0 && durationSeconds > 0
                 ? durationSeconds / (distanceMeters / 1000.0)
                 : 0;
 
-            var calculated = ExtractCalculatedMetrics(rawGpxDataJson);
-            var startedAtUtc = ToUtc(startTime);
+            var calculated = ExtractCalculatedMetrics(decoded.RawGpxDataJson);
 
             var existingWorkout = await WorkoutQueryService.FindDuplicateWorkoutAsync(
                 _db, startedAtUtc, distanceMeters, durationSeconds);
 
             if (existingWorkout != null)
             {
-                return await HandleDuplicateAsync(
-                    existingWorkout,
-                    rawFileData,
-                    fileName,
-                    fileType,
-                    rawGpxDataJson,
-                    rawFitDataJson,
-                    trackPoints,
-                    startedAtUtc,
-                    distanceMeters,
-                    durationSeconds,
-                    parseResult,
-                    fitResult);
+                return await HandleDuplicateAsync(existingWorkout, decoded, startedAtUtc);
             }
 
-            var workout = CreateWorkoutEntity(
-                startedAtUtc,
-                durationSeconds,
-                distanceMeters,
-                avgPaceS,
-                rawFileData,
-                fileName,
-                fileType,
-                rawGpxDataJson,
-                rawFitDataJson,
-                isGpx,
-                parseResult?.Name,
-                overlay);
+            var workout = CreateWorkoutEntity(decoded, startedAtUtc, avgPaceS, overlay);
 
-            PopulateWorkoutMetrics(workout, calculated, fitResult, rawFitDataJson);
+            PopulateWorkoutMetrics(workout, calculated, decoded.RawFitDataJson);
             PopulateMetricsFromStrava(workout, overlay?.RawStravaDataJson);
 
             var splitDistanceMeters = await GetSplitDistanceMetersAsync();
@@ -145,7 +172,7 @@ public class WorkoutIntake
                 workout.Id,
                 distanceMeters,
                 durationSeconds,
-                parseResult != null ? null : fitResult?.SeriesPoints);
+                decoded.SeriesPoints);
 
             workout.ElevGainM = geometry.ElevGainM;
 
@@ -156,13 +183,13 @@ public class WorkoutIntake
             {
                 CalculateAggregateMetricsFromTimeSeries(workout, timeSeries);
             }
-            else if (parseResult == null && fitResult != null)
+            else if (!string.IsNullOrEmpty(decoded.RawFitDataJson) && decoded.SeriesPoints != null)
             {
                 _logger.LogInformation("FIT file imported with no sensor data. Workout created with available data (GPS, elevation, distance).");
             }
 
             await FetchAndAttachWeatherAsync(
-                workout, trackPoints, overlay?.RawStravaDataJson, rawFitDataJson, startedAtUtc);
+                workout, trackPoints, overlay?.RawStravaDataJson, decoded.RawFitDataJson, startedAtUtc);
             await AssignDefaultShoeAsync(workout);
 
             _db.Workouts.Add(workout);
@@ -196,30 +223,30 @@ public class WorkoutIntake
         }
         catch (InvalidOperationException ex)
         {
-            _logger.LogError(ex, "Error parsing workout file");
+            _logger.LogError(ex, "Error persisting workout");
             return Error(ex.Message);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error importing workout file");
+            _logger.LogError(ex, "Error persisting workout");
             return Error(ex.Message);
         }
     }
 
     private async Task<WorkoutIntakeResult> HandleDuplicateAsync(
         Workout existingWorkout,
-        byte[] rawFileData,
-        string fileName,
-        string fileType,
-        string? rawGpxDataJson,
-        string? rawFitDataJson,
-        List<TrackPoint> trackPoints,
-        DateTime startedAtUtc,
-        double distanceMeters,
-        int durationSeconds,
-        GpxParserService.GpxParseResult? parseResult,
-        FitParserService.FitParseResult? fitResult)
+        DecodedWorkout decoded,
+        DateTime startedAtUtc)
     {
+        var fileName = decoded.RawFileName ?? string.Empty;
+        var fileType = decoded.RawFileType ?? string.Empty;
+        var rawFileData = decoded.RawFileData;
+        var rawGpxDataJson = decoded.RawGpxDataJson;
+        var rawFitDataJson = decoded.RawFitDataJson;
+        var trackPoints = decoded.TrackPoints;
+        var distanceMeters = decoded.DistanceM;
+        var durationSeconds = decoded.DurationS;
+
         var needsRawFileUpdate = existingWorkout.RawFileData == null || existingWorkout.RawFileData.Length == 0;
         var needsRawJsonUpdate = fileType == "fit"
             ? IsFitJsonIncomplete(existingWorkout.RawFitData)
@@ -240,7 +267,7 @@ public class WorkoutIntake
 
         await _db.Entry(existingWorkout).Reference(w => w.Route).LoadAsync();
 
-        if (needsRawFileUpdate)
+        if (needsRawFileUpdate && rawFileData != null && rawFileData.Length > 0)
         {
             existingWorkout.RawFileData = rawFileData;
             existingWorkout.RawFileName = fileName;
@@ -269,7 +296,7 @@ public class WorkoutIntake
                 existingWorkout.Id,
                 distanceMeters,
                 durationSeconds,
-                parseResult != null ? null : fitResult?.SeriesPoints);
+                decoded.SeriesPoints);
 
             var oldSplits = await _db.WorkoutSplits.Where(s => s.WorkoutId == existingWorkout.Id).ToListAsync();
             _db.WorkoutSplits.RemoveRange(oldSplits);
@@ -338,20 +365,47 @@ public class WorkoutIntake
         }
     }
 
-    private static (DateTime StartTime, int DurationSeconds, double DistanceMeters,
-        List<TrackPoint> TrackPoints, string? RawGpxDataJson, string? RawFitDataJson)
-        ExtractParseResultData(GpxParserService.GpxParseResult? parseResult, FitParserService.FitParseResult? fitResult)
+    private static DecodedWorkout ToDecodedWorkout(
+        GpxParserService.GpxParseResult? parseResult,
+        FitParserService.FitParseResult? fitResult,
+        byte[] rawFileData,
+        string fileName,
+        string fileType)
     {
         if (parseResult != null)
         {
-            return (parseResult.StartTime, parseResult.DurationSeconds, parseResult.DistanceMeters,
-                parseResult.TrackPoints, parseResult.RawGpxDataJson, null);
+            return new DecodedWorkout
+            {
+                StartedAt = parseResult.StartTime,
+                DurationS = parseResult.DurationSeconds,
+                DistanceM = parseResult.DistanceMeters,
+                TrackPoints = parseResult.TrackPoints,
+                SeriesPoints = null,
+                Name = parseResult.Name,
+                RawGpxDataJson = parseResult.RawGpxDataJson,
+                RawFitDataJson = null,
+                RawFileData = rawFileData,
+                RawFileName = fileName,
+                RawFileType = fileType
+            };
         }
 
         if (fitResult != null)
         {
-            return (fitResult.StartTime, fitResult.DurationSeconds, fitResult.DistanceMeters,
-                fitResult.TrackPoints, null, fitResult.RawFitDataJson);
+            return new DecodedWorkout
+            {
+                StartedAt = fitResult.StartTime,
+                DurationS = fitResult.DurationSeconds,
+                DistanceM = fitResult.DistanceMeters,
+                TrackPoints = fitResult.TrackPoints,
+                SeriesPoints = fitResult.SeriesPoints,
+                Name = null,
+                RawGpxDataJson = null,
+                RawFitDataJson = fitResult.RawFitDataJson,
+                RawFileData = rawFileData,
+                RawFileName = fileName,
+                RawFileType = fileType
+            };
         }
 
         throw new InvalidOperationException("Failed to parse file");
@@ -385,31 +439,26 @@ public class WorkoutIntake
     }
 
     private static Workout CreateWorkoutEntity(
+        DecodedWorkout decoded,
         DateTime startedAtUtc,
-        int durationSeconds,
-        double distanceMeters,
         double avgPaceS,
-        byte[] rawFileData,
-        string fileName,
-        string fileType,
-        string? rawGpxDataJson,
-        string? rawFitDataJson,
-        bool isGpx,
-        string? gpxName,
         WorkoutIntakeOverlay? overlay)
     {
+        var fileType = decoded.RawFileType ?? string.Empty;
+        var isGpx = fileType == "gpx";
+
         var workout = new Workout
         {
             Id = Guid.NewGuid(),
             StartedAt = startedAtUtc,
-            DurationS = durationSeconds,
-            DistanceM = distanceMeters,
+            DurationS = decoded.DurationS,
+            DistanceM = decoded.DistanceM,
             AvgPaceS = avgPaceS,
-            RawFileData = rawFileData,
-            RawFileName = fileName,
-            RawFileType = fileType,
-            RawGpxData = rawGpxDataJson,
-            RawFitData = rawFitDataJson,
+            RawFileData = decoded.RawFileData,
+            RawFileName = decoded.RawFileName,
+            RawFileType = decoded.RawFileType,
+            RawGpxData = decoded.RawGpxDataJson,
+            RawFitData = decoded.RawFitDataJson,
             Source = overlay?.Source ?? (isGpx ? "gpx_import" : "fit_import"),
             RunType = "Easy Run",
             CreatedAt = DateTime.UtcNow
@@ -419,9 +468,9 @@ public class WorkoutIntake
         {
             workout.Name = overlay.Name;
         }
-        else if (!string.IsNullOrWhiteSpace(gpxName))
+        else if (!string.IsNullOrWhiteSpace(decoded.Name))
         {
-            workout.Name = gpxName;
+            workout.Name = decoded.Name;
         }
 
         if (!string.IsNullOrWhiteSpace(overlay?.Notes))
@@ -440,7 +489,6 @@ public class WorkoutIntake
     private void PopulateWorkoutMetrics(
         Workout workout,
         Dictionary<string, object> calculated,
-        FitParserService.FitParseResult? fitResult,
         string? rawFitDataJson)
     {
         if (calculated.TryGetValue("elevLossM", out var elevLoss) && elevLoss is JsonElement elevLossElem && elevLossElem.ValueKind == JsonValueKind.Number)
@@ -454,7 +502,7 @@ public class WorkoutIntake
         if (calculated.TryGetValue("avgSpeedMps", out var avgSpeed) && avgSpeed is JsonElement avgSpeedElem && avgSpeedElem.ValueKind == JsonValueKind.Number)
             workout.AvgSpeedMps = avgSpeedElem.GetDouble();
 
-        if (fitResult != null && !string.IsNullOrEmpty(rawFitDataJson))
+        if (!string.IsNullOrEmpty(rawFitDataJson))
         {
             try
             {

--- a/api/Tempo.Api.Tests/Services/WorkoutIntakeTests.cs
+++ b/api/Tempo.Api.Tests/Services/WorkoutIntakeTests.cs
@@ -210,6 +210,40 @@ public class WorkoutIntakeTests : IDisposable
         (await _db.Workouts.CountAsync()).Should().Be(0);
     }
 
+    [Fact]
+    public async Task PersistAsync_Created_FromDecodedWorkoutWithoutFileAdapter()
+    {
+        await TestDataSeeder.SeedUserSettingsAsync(_db);
+        using var stream = CreateGpxStream();
+        var rawFileData = stream.ToArray();
+        stream.Position = 0;
+        var parsed = _gpxParser.ParseGpx(stream);
+
+        var decoded = new DecodedWorkout
+        {
+            StartedAt = parsed.StartTime,
+            DurationS = parsed.DurationSeconds,
+            DistanceM = parsed.DistanceMeters,
+            TrackPoints = parsed.TrackPoints,
+            SeriesPoints = null,
+            Name = parsed.Name,
+            RawGpxDataJson = parsed.RawGpxDataJson,
+            RawFileData = rawFileData,
+            RawFileName = "morning.gpx",
+            RawFileType = "gpx"
+        };
+
+        var result = await _intake.PersistAsync(decoded);
+
+        result.Action.Should().Be("created");
+        result.Workout.Should().NotBeNull();
+        result.SplitsCount.Should().BeGreaterThan(0);
+        (await _db.Workouts.CountAsync()).Should().Be(1);
+        _weather.CallCount.Should().Be(1);
+        _relativeEffort.CallCount.Should().Be(1);
+        _bestEfforts.CallCount.Should().Be(1);
+    }
+
     private static MemoryStream CreateGpxStream()
     {
         var xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>

--- a/docs/PRD-tempo-ios-healthkit-import.md
+++ b/docs/PRD-tempo-ios-healthkit-import.md
@@ -1,0 +1,155 @@
+# PRD: HealthKit Workout Import for tempo-ios
+
+**Status:** Draft
+**Date:** 2026-08-30
+**Audience:** tempo-ios team (primary), tempo API maintainers (backend requirements in §7)
+
+---
+
+## 1. Background
+
+Tempo currently requires users to manually upload FIT/GPX files for every workout. That is fine for privacy-focused users, but it is a real adoption barrier for users who just want Tempo's benefits (self-hosted analytics, MCP access via tempo-cli, the iOS app) without a manual chore after every run.
+
+Server-side integrations were researched and rejected for now:
+
+- **Strava API** requires each self-hoster to hold a paid Strava subscription for API credentials, cannot return original FIT/GPX files (streams only), and its API Policy (June 2026) explicitly prohibits using Strava-sourced data in AI applications or exposing it via MCP servers — directly at odds with tempo-cli.
+- **Garmin's** official developer program is enterprise-only and currently paused for new applications; unofficial access requires storing the user's Garmin password and breaks regularly.
+
+**HealthKit avoids all of this.** It is a free, stable, on-device API with per-type user consent, no third-party terms restricting downstream use, and full-fidelity data for Apple Watch recordings: GPS route (`HKWorkoutRoute`), continuous heart rate, cadence, and running power. The iOS app becomes the sync agent between the user's Health store and their Tempo server.
+
+### Known data-fidelity constraints (verified)
+
+- **Apple Watch / Apple Workout app** recordings: full fidelity (route, HR stream, cadence, power).
+- **Garmin Connect** writes only summary-grade workouts to Apple Health: no GPS route, no HR stream (min/max only), and backfills only ~2 weeks. **Strava's** Health writes are similarly summary-grade.
+- HealthKit **background delivery is best-effort and batched**: typically 1–60 minutes after a workout, even at "immediate" frequency. It is not real-time and can be skipped by iOS entirely.
+
+This feature primarily serves Apple Watch runners. Garmin/Strava-sourced Health entries are excluded by default (see §5.3) because they would import as degraded shadow copies.
+
+---
+
+## 2. Goals
+
+1. A user can connect Apple Health to tempo-ios and import any or all of their historical runs into their Tempo server, with clear indication of which runs are already in Tempo.
+2. With auto-sync enabled, new runs are detected in the background, staged for review, and imported with a single tap — no file handling, no Mac, no cables.
+3. Imported runs are first-class Tempo workouts: route, splits, time series, heart rate, weather, default shoe, relative effort, and best efforts all populate exactly as they do for a manually uploaded file.
+4. Re-syncing is always safe: no duplicates, ever, regardless of retries, reinstalls, or overlap with workouts already imported via GPX/FIT upload or Strava bulk import.
+
+## 3. Non-goals (v1)
+
+- **Other sports.** Running only (`HKWorkoutActivityType.running`), outdoor and indoor. No walking, hiking, or cycling until Tempo has a sport concept.
+- **Writing to HealthKit.** No two-way sync; Tempo never writes workouts back to Health.
+- **Silent auto-import.** All imports go through user review (see §5.4). Revisit after v1 telemetry.
+- **Server-side fuzzy deduplication.** The source filter plus UUID idempotency covers the realistic cases; time/distance-tolerance matching is deliberately out.
+- **Server-side ignore tombstones.** The ignore list is on-device only (see §5.5); it does not survive reinstall.
+- **Strava/Garmin server integrations.** Separate decision, previously researched and deferred.
+- **Media.** HealthKit has no workout photos; nothing to import.
+
+---
+
+## 4. User stories
+
+1. As a new Tempo user with three years of Apple Watch runs, I connect Health, review my history, select the runs I want, and watch them import with progress — then see them fully populated on my Tempo dashboard.
+2. As a daily runner, I finish a run, and within the hour my phone notifies me that the run is ready to review; one tap in tempo-ios approves it into Tempo.
+3. As a treadmill runner, my indoor runs import with distance, duration, and heart rate even though they have no GPS route.
+4. As a user who also did a one-time Strava ZIP bulk import, I never see duplicates when I later connect HealthKit.
+5. As a user who dismissed a junk workout from the review queue, I never see it offered again on this device.
+
+---
+
+## 5. Product requirements — iOS
+
+### 5.1 Connect flow
+
+- New **Settings → Apple Health** section: connect, disconnect, source filter, auto-sync toggle, ignore-list management, sync activity log.
+- Connecting requests read authorization for: workouts, workout routes, heart rate, running cadence (step count during workout), running power, distance, and active energy. Handle partial/denied grants gracefully — HealthKit does not reveal read-denial, so the UX copy must explain that missing data usually means denied permissions, with a deep link to Health settings.
+- Connection state, sync anchors, and the ignore list persist locally on device.
+
+### 5.2 History picker (manual import + backfill)
+
+- Lists the user's full HealthKit running history (allowlisted sources only), newest first, with per-run: date, distance, duration, source app, and an **already-in-Tempo badge** (matched by stored HealthKit UUID, falling back to the server's start/distance/duration duplicate check).
+- **Selection is explicit.** Multi-select is supported, but there is no prominent "Import all" one-tap action; the user reviews and chooses. (Product decision: review-first over bulk convenience.)
+- Import runs sequentially with visible progress (n of m), survives interruption, and is resumable — safe because every POST is idempotent by HealthKit UUID.
+- Per-run context action: **"Don't ask again"** → adds to the on-device ignore list.
+
+### 5.3 Source filter
+
+- Default allowlist: workouts whose source is Apple's own recorders (Apple Watch / Apple Workout app). Rationale: Garmin Connect and Strava write summary-only shadow copies (no route, no HR stream) of runs that usually exist in Tempo at full fidelity already.
+- The user can view all source apps present in their Health store and opt additional sources in. When a non-default source is enabled, show a one-time notice that those workouts may lack route and heart-rate detail.
+
+### 5.4 Auto-sync (staged review)
+
+- Opt-in toggle. Implementation: `HKObserverQuery` registered at app launch + `enableBackgroundDelivery` for the workout type + `HKAnchoredObjectQuery` for deltas; upload via background `URLSession`.
+- When new allowlisted runs are detected, they are **staged into a review queue — never imported silently.** A local notification ("1 run ready to import") deep-links to the queue.
+- The review queue shows the same card as the picker (date, distance, duration, source) with per-run approve, multi-select approve, and dismiss (dismiss = ignore list).
+- On every app foreground, run the same anchored delta check as a fallback — background delivery is best-effort and must not be the only trigger.
+- Engineering notes (known HealthKit failure modes): observer queries must be re-registered on every launch before anything else; the observer's completion handler must always be called or iOS permanently stops background wakes; background delivery does not work on Simulator — test on hardware.
+
+### 5.5 Ignore list and deletion semantics
+
+- Dismissing a run (queue) or "Don't ask again" (picker) adds its HealthKit UUID to an **on-device ignore list**: never shown in the picker, never staged. Viewable and clearable in Settings → Apple Health.
+- If the user deletes a synced workout in Tempo, the run **reappears in the picker as importable** (deletion may have been a mistake) but is **never auto-staged again** by auto-sync.
+
+### 5.6 Sync activity log
+
+- Reverse-chronological log in Settings → Apple Health: staged, imported, dismissed, and failed events with timestamps and error detail on failures. Local only.
+
+---
+
+## 6. Data mapping
+
+The iOS app is responsible for assembling one JSON document per workout:
+
+| Tempo concept | HealthKit source |
+| --- | --- |
+| Start time / duration | `HKWorkout.startDate`, `.duration` |
+| Distance | `HKWorkout` distance statistic (authoritative, device summary) |
+| Route points | `HKWorkoutRoute` → timestamped `CLLocation`s (lat, lon, altitude) |
+| Heart rate series | HR quantity samples within the workout interval |
+| Cadence / power | Running cadence and power samples where present |
+| Energy | Active energy statistic |
+| Indoor flag | `HKWorkout.isIndoorWorkout` / metadata |
+| External ID | `HKWorkout.uuid` |
+| Source app | `HKSourceRevision` (name + bundle ID) |
+
+The app merges HR/cadence/power samples onto route points by timestamp (nearest-sample within a tolerance) to produce a single track-point array. For indoor runs the array may be empty or GPS-free; include cumulative distance samples when available so the server can compute splits and time series without GPS.
+
+---
+
+## 7. Backend requirements (tempo API)
+
+1. **New endpoint** `POST /workouts/import/healthkit` (JWT-protected, same as all workout endpoints). Accepts one workout per request: summary block (start, duration, distance, energy, avg/max HR, indoor flag, source app), track-point array, HealthKit UUID, and a schema version field.
+2. Feeds the existing `WorkoutIntake` pipeline: summary block is treated as the authoritative device summary (same precedence as FIT session data); `TrackGeometry` derives route, splits, and time series; weather, default shoe, relative effort, and best efforts run unchanged. Indoor runs follow the existing routeless path already supported for FIT files.
+3. **Idempotency:** persist the HealthKit UUID on the workout (new nullable external-ID column). Duplicate check order: UUID match → return the existing workout (200-equivalent "skipped/exists" result, not an error) → existing start/distance/duration rule as backstop.
+4. Store the raw request payload in a JSONB column following the `RawStravaData` pattern, so future reprocessing (e.g., improved split derivation) can rehydrate from source.
+5. Response mirrors the existing import result shape (`created` / `updated` / `skipped` + workout ID) so the app can badge accurately.
+
+---
+
+## 8. Edge cases
+
+- **Runs with no distance and no route** (rare, bad third-party writes): reject client-side with a clear "not enough data" state in the picker; do not send.
+- **Watch-only user with poor connectivity:** background `URLSession` retries; queue state must survive app termination.
+- **Permission revoked after connect:** anchored queries silently return nothing new; surface "check Health permissions" in the sync log rather than failing silently forever.
+- **Very long runs** (ultra-distance, 10k+ route points): cap/downsample client-side to a bounded payload consistent with existing time-series limits (20,000 samples).
+- **Duplicate across devices** (user runs tempo-ios on two devices): server-side UUID idempotency makes this safe; second device shows the run as already imported.
+
+---
+
+## 9. Success metrics
+
+- ≥ 80% of runs from connected users arrive via HealthKit (vs manual upload) within 60 days of release.
+- Median time from workout end to "staged in queue" under 60 minutes; from staging to import driven by user action (report distribution).
+- Zero duplicate workouts reported from HealthKit-sourced imports.
+- Backfill completion rate: of users who open the history picker, % who import ≥ 1 run.
+
+## 10. Open questions
+
+1. Does tempo-ios already hold a persistent authenticated session suitable for background `URLSession` uploads (cookie refresh while backgrounded)? If tokens can expire mid-queue, the staging model tolerates it, but the sync log must explain re-auth.
+2. Should the review queue eventually offer an "auto-approve runs from Apple Watch" escalation once trust is established? (Deferred; revisit with v1 telemetry.)
+3. Minimum iOS version: running power and some metadata require iOS 16+; confirm tempo-ios's current deployment target.
+
+## 11. Phasing
+
+- **M1 — Manual path:** connect flow, source filter, history picker with badges, JSON endpoint + UUID idempotency on the API, sequential import with progress, ignore list.
+- **M2 — Auto-sync:** observer/background delivery, staging queue, notifications, foreground fallback, sync log.
+- Both milestones ship in one release; M1 is independently testable and gates M2.

--- a/docs/developers/architecture.md
+++ b/docs/developers/architecture.md
@@ -56,7 +56,7 @@ Each extension method:
 - `GpxParserService` / `FitParserService` — decode adapters: `TrackPoint`s, raw JSON, optional device summary (and GPX name). They do not expose `CalculateSplits` and do not hand FIT `RecordMesg` to callers. The FIT SDK is compiled from `api/Libraries/FitSDK/` (not a NuGet package).
 - `StravaCsvParserService` — parses Strava export CSV metadata for bulk ZIP import.
 - `TrackGeometry` — in-process: `TrackPoint`s in; elevation gain, `WorkoutRoute`, `WorkoutSplit`s, `WorkoutTimeSeries` out. No `DbContext`.
-- `WorkoutIntake` — one persist pipeline (parse, geometry, duplicate policy, default shoe, weather, relative effort, incremental best efforts). HTTP import is a thin adapter. Bulk calls intake per activity file.
+- `WorkoutIntake` — decode adapters (GPX/FIT file → `DecodedWorkout`) feed `PersistAsync` (geometry, duplicate policy, default shoe, weather, relative effort, incremental best efforts). Persist is the single pipeline; HTTP import is a thin file adapter. Bulk calls intake per activity file.
 - `TrackPointRehydration` — stored Workout fields → `TrackPoint`s for crop and split recalc.
 - `ImportJobService` — create/chunk/complete/current/get/cancel, one-active-job rules, archive staging under `media/imports/{jobId}/`.
 - `ImportJobWorker` — hosted service; wakes on channel, new DI scope per job; branches on `kind` (`strava_bulk` | `tempo_export`).
@@ -115,8 +115,8 @@ This ensures migrations can be safely applied even when database state doesn't m
 
 1. File uploaded to `POST /workouts/import`
 2. HTTP maps `IFormFile` to `WorkoutIntake` (stream + filename)
-3. Parser decode: GPX or FIT → `TrackPoint`s, raw JSON, optional device summary
-4. `TrackGeometry.Derive` builds elevation, route, splits, and time series (device summary wins for distance/duration when present)
+3. File decode adapter: GPX or FIT → `DecodedWorkout` (`TrackPoint`s, raw JSON, optional device summary)
+4. `PersistAsync` → `TrackGeometry.Derive` builds elevation, route, splits, and time series (device summary wins for distance/duration when present)
 5. Duplicate policy: same key (`StartedAt`, `DistanceM`, `DurationS`); incomplete raw JSON/bytes can `updated`; complete duplicates `skipped`
 6. Weather, default shoe, relative effort, incremental best efforts
 7. Workout persisted with JSONB raw data and `WorkoutRoute`

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -116,7 +116,7 @@ Include:
 
 ### Features
 
-- New workout import formats (decode adapter → `WorkoutIntake`; do not add a second persist pipeline in HTTP or bulk)
+- New workout import formats (decode adapter → `DecodedWorkout` → `WorkoutIntake.PersistAsync`; do not add a second persist pipeline in HTTP or bulk)
 - Additional analytics and statistics
 - Integration with other services
 

--- a/docs/developers/testing.md
+++ b/docs/developers/testing.md
@@ -9,7 +9,7 @@ The Tempo API uses **xUnit** for testing with **coverlet** for code coverage col
 - **Unit Tests**: Test individual services in isolation (located in `api/Tempo.Api.Tests/Services/`)
   - Parser tests (`GpxParserServiceTests`, `FitParserServiceTests`) assert decode: fixture file → `TrackPoint`s and optional device summary, not split counts or elevation-gain algorithm details
   - `TrackGeometryTests` assert elevation, split boundaries, GeoJSON, and series elapsed-seconds from fixture `TrackPoint` lists (no `DbContext`)
-  - `WorkoutIntakeTests` cover `created` / `updated` / `skipped` / `error` with faked weather, relative effort, and best efforts; persist and duplicate stay real
+  - `WorkoutIntakeTests` cover `created` / `updated` / `skipped` / `error` with faked weather, relative effort, and best efforts; persist and duplicate stay real. Includes a `PersistAsync` seam test that builds `DecodedWorkout` without the file adapter.
 - **Integration Tests**: Test endpoints and full request/response cycles (located in `api/Tempo.Api.Tests/IntegrationTests/`)
   - Import-job and Tempo export-import tests (`ImportJobTests`, `ImportExportTests`) poll `GET /workouts/import/jobs/{id}` until `completed` or `failed`. Do not expect a blocking **200** summary from `POST /workouts/import/bulk` or `POST /workouts/import/export` (those adapters return **202**).
 


### PR DESCRIPTION
- Introduced a new `DecodedWorkout` class to streamline the workout persist pipeline, allowing for direct decoding from GPX/FIT files.
- Updated `WorkoutIntake` to utilize `DecodedWorkout` in the `PersistAsync` method, consolidating the import process for various file formats.
- Enhanced documentation to reflect changes in the workout intake architecture and the new decoding approach.
- Added unit tests to validate the new functionality, ensuring robust handling of workouts without file adapters.