### PR TITLE
feat: add endpoint to list HealthKit UUIDs from workouts

### DIFF
--- a/api/Endpoints/WorkoutsEndpoints.cs
+++ b/api/Endpoints/WorkoutsEndpoints.cs
@@ -151,6 +151,21 @@ public static class WorkoutsEndpoints
     }
 
     /// <summary>
+    /// List HealthKit UUIDs stored on workouts
+    /// </summary>
+    /// <param name="db">Database context</param>
+    /// <returns>Object with uuids array of non-null HealthKitUuid values</returns>
+    /// <remarks>
+    /// Returns HealthKitUuid values stored on workouts (nulls omitted). Used by tempo-ios to badge
+    /// already-imported runs without paging GET /workouts.
+    /// </remarks>
+    private static async Task<IResult> ListHealthKitUuids(TempoDbContext db)
+    {
+        var uuids = await WorkoutQueryService.ListHealthKitUuidsAsync(db);
+        return Results.Ok(new { uuids });
+    }
+
+    /// <summary>
     /// List workouts with pagination and filtering
     /// </summary>
     /// <param name="db">Database context</param>
@@ -2253,6 +2268,13 @@ public static class WorkoutsEndpoints
             .Produces(401)
             .WithSummary("Import HealthKit workout")
             .WithDescription("Accepts a schema-versioned HealthKit workout JSON document from tempo-ios (outdoor GPS or indoor DistM/summary). Feeds the same PersistAsync pipeline as file import.");
+
+        group.MapGet("/healthkit-uuids", ListHealthKitUuids)
+            .WithName("ListHealthKitUuids")
+            .Produces(200)
+            .Produces(401)
+            .WithSummary("List HealthKit UUIDs")
+            .WithDescription("Returns HealthKitUuid values stored on workouts (nulls omitted). Used by tempo-ios to badge already-imported runs without paging GET /workouts.");
 
         group.MapGet("", ListWorkouts)
         .WithName("ListWorkouts")

--- a/api/Services/WorkoutQueryService.cs
+++ b/api/Services/WorkoutQueryService.cs
@@ -19,6 +19,19 @@ public static class WorkoutQueryService
     }
 
     /// <summary>
+    /// Returns all non-null HealthKitUuid values stored on workouts (nulls omitted).
+    /// Used by tempo-ios to badge already-imported runs without paging GET /workouts.
+    /// </summary>
+    public static async Task<IReadOnlyList<Guid>> ListHealthKitUuidsAsync(TempoDbContext db)
+    {
+        return await db.Workouts
+            .AsNoTracking()
+            .Where(w => w.HealthKitUuid != null)
+            .Select(w => w.HealthKitUuid!.Value)
+            .ToListAsync();
+    }
+
+    /// <summary>
     /// Finds a duplicate workout based on start time, distance, and duration.
     /// A workout is considered a duplicate if it has the same start time and very similar distance and duration.
     /// </summary>

--- a/api/Tempo.Api.Tests/IntegrationTests/ListHealthKitUuidsTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/ListHealthKitUuidsTests.cs
@@ -1,0 +1,100 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Tempo.Api.Data;
+using Tempo.Api.Tests.Infrastructure;
+using Xunit;
+
+namespace Tempo.Api.Tests.IntegrationTests;
+
+/// <summary>
+/// Integration tests for GET /workouts/healthkit-uuids
+/// </summary>
+[Collection("Integration Tests")]
+public class ListHealthKitUuidsTests : IClassFixture<TempoWebApplicationFactory>
+{
+    private readonly TempoWebApplicationFactory _factory;
+
+    public ListHealthKitUuidsTests(TempoWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    private async Task EnsureCleanDatabaseAsync()
+    {
+        using var scope = _factory.Server.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+        await TestDataSeeder.SafeClearAllDataAsync(db, preserveUsers: true);
+    }
+
+    [Fact]
+    public async Task ListHealthKitUuids_Returns401_WhenNotAuthenticated()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/workouts/healthkit-uuids");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ListHealthKitUuids_ReturnsEmptyArray_WhenNoHealthKitRows()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            await TestDataSeeder.SeedWorkoutAsync(db, name: "GPX only");
+        }
+
+        var response = await client.GetAsync("/workouts/healthkit-uuids");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<HealthKitUuidsResponse>();
+        result.Should().NotBeNull();
+        result!.Uuids.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListHealthKitUuids_ReturnsOnlyNonNullUuids()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        var uuid1 = Guid.Parse("A1B2C3D4-E5F6-7890-ABCD-EF1234567890");
+        var uuid2 = Guid.Parse("B2C3D4E5-F6A7-8901-BCDE-F12345678901");
+
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+
+            var stamped1 = await TestDataSeeder.SeedWorkoutAsync(db, name: "HK 1");
+            stamped1.HealthKitUuid = uuid1;
+
+            await TestDataSeeder.SeedWorkoutAsync(db, name: "GPX only");
+
+            var stamped2 = await TestDataSeeder.SeedWorkoutAsync(db, name: "HK 2");
+            stamped2.HealthKitUuid = uuid2;
+
+            await db.SaveChangesAsync();
+        }
+
+        var response = await client.GetAsync("/workouts/healthkit-uuids");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<HealthKitUuidsResponse>();
+        result.Should().NotBeNull();
+        result!.Uuids.Should().BeEquivalentTo(new[] { uuid1, uuid2 });
+    }
+
+    private sealed class HealthKitUuidsResponse
+    {
+        [JsonPropertyName("uuids")]
+        public List<Guid> Uuids { get; set; } = [];
+    }
+}

--- a/api/Tempo.Api.Tests/Services/WorkoutQueryServiceTests.cs
+++ b/api/Tempo.Api.Tests/Services/WorkoutQueryServiceTests.cs
@@ -266,5 +266,57 @@ public class WorkoutQueryServiceTests : IDisposable
         // Should return one of the matches (FirstOrDefault behavior)
         (result!.Id == workout1.Id || result.Id == workout2.Id).Should().BeTrue();
     }
+
+    [Fact]
+    public async Task ListHealthKitUuidsAsync_ReturnsEmpty_WhenNoWorkoutsExist()
+    {
+        var result = await WorkoutQueryService.ListHealthKitUuidsAsync(_db);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListHealthKitUuidsAsync_ReturnsOnlyNonNullUuids()
+    {
+        var uuid1 = Guid.Parse("A1B2C3D4-E5F6-7890-ABCD-EF1234567890");
+        var uuid2 = Guid.Parse("B2C3D4E5-F6A7-8901-BCDE-F12345678901");
+
+        _db.Workouts.AddRange(
+            new Workout
+            {
+                StartedAt = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+                DistanceM = 5000,
+                DurationS = 1800,
+                AvgPaceS = 360,
+                Source = "test",
+                HealthKitUuid = uuid1,
+                CreatedAt = DateTime.UtcNow
+            },
+            new Workout
+            {
+                StartedAt = new DateTime(2024, 1, 16, 10, 0, 0, DateTimeKind.Utc),
+                DistanceM = 5000,
+                DurationS = 1800,
+                AvgPaceS = 360,
+                Source = "test",
+                HealthKitUuid = null,
+                CreatedAt = DateTime.UtcNow
+            },
+            new Workout
+            {
+                StartedAt = new DateTime(2024, 1, 17, 10, 0, 0, DateTimeKind.Utc),
+                DistanceM = 5000,
+                DurationS = 1800,
+                AvgPaceS = 360,
+                Source = "test",
+                HealthKitUuid = uuid2,
+                CreatedAt = DateTime.UtcNow
+            });
+        await _db.SaveChangesAsync();
+
+        var result = await WorkoutQueryService.ListHealthKitUuidsAsync(_db);
+
+        result.Should().BeEquivalentTo(new[] { uuid1, uuid2 });
+    }
 }
 

--- a/api/bruno/Tempo.Api/Workouts/List HealthKit UUIDs.bru
+++ b/api/bruno/Tempo.Api/Workouts/List HealthKit UUIDs.bru
@@ -1,0 +1,40 @@
+meta {
+  name: List HealthKit UUIDs
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/workouts/healthkit-uuids
+  body: none
+  auth: inherit
+}
+
+example {
+  name: 200 Response
+  description: OK
+  
+  request: {
+    url: {{baseUrl}}/workouts/healthkit-uuids
+    method: GET
+    mode: none
+  }
+  
+  response: {
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: text
+      content: '''
+{
+  "uuids": [
+    "A1B2C3D4-E5F6-7890-ABCD-EF1234567890"
+  ]
+}
+      '''
+    }
+  }
+}

--- a/docs/PRD-tempo-ios-healthkit-import.md
+++ b/docs/PRD-tempo-ios-healthkit-import.md
@@ -122,6 +122,7 @@ The app merges HR/cadence/power samples onto route points by timestamp (nearest-
 3. **Idempotency:** persist the HealthKit UUID on the workout (new nullable external-ID column). Duplicate check order: UUID match → return the existing workout (200-equivalent "skipped/exists" result, not an error) → existing start/distance/duration rule as backstop.
 4. Store the raw request payload in a JSONB column following the `RawStravaData` pattern, so future reprocessing (e.g., improved split derivation) can rehydrate from source.
 5. Response mirrors the existing import result shape (`created` / `updated` / `skipped` + workout ID) so the app can badge accurately.
+6. **UUID index** `GET /workouts/healthkit-uuids` returns `{ "uuids": [...] }` of all non-null `HealthKitUuid` values so tempo-ios can badge the history picker without paging `GET /workouts`.
 
 ---
 

--- a/docs/developers/api-reference.md
+++ b/docs/developers/api-reference.md
@@ -377,6 +377,27 @@ Query parameters:
 
 List and detail responses include nullable `healthKitUuid` for tempo-ios already-imported badging.
 
+### List HealthKit UUIDs
+
+Returns all non-null `HealthKitUuid` values stored on workouts (nulls omitted). Used by tempo-ios to badge already-imported runs without paging `GET /workouts`.
+
+```http
+GET /workouts/healthkit-uuids
+```
+
+Requires authentication. Response:
+
+```json
+{
+  "uuids": [
+    "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+    "B2C3D4E5-F6A7-8901-BCDE-F12345678901"
+  ]
+}
+```
+
+Empty library or GPX/FIT-only library → `{ "uuids": [] }`. Unpaginated; no Tempo workout ids.
+
 ### Get Workout
 
 Get detailed workout information:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1063,6 +1063,29 @@
         ]
       }
     },
+    "/workouts/healthkit-uuids": {
+      "get": {
+        "tags": [
+          "Workouts"
+        ],
+        "summary": "List HealthKit UUIDs stored on workouts",
+        "description": "Returns HealthKitUuid values stored on workouts (nulls omitted). Used by tempo-ios to badge\nalready-imported runs without paging GET /workouts.",
+        "operationId": "ListHealthKitUuids",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [ ]
+          }
+        ]
+      }
+    },
     "/workouts": {
       "get": {
         "tags": [


### PR DESCRIPTION
- Introduced a new API endpoint `/workouts/healthkit-uuids` to retrieve all non-null HealthKit UUIDs associated with workouts, enhancing the ability for tempo-ios to badge already-imported runs without paging through workouts.
- Implemented the `ListHealthKitUuids` method in `WorkoutsEndpoints` and the corresponding service method in `WorkoutQueryService`.
- Added integration tests to ensure the endpoint behaves correctly, including authentication checks and response validation.
- Updated OpenAPI documentation and developer reference to include the new endpoint and its specifications.