### PR TITLE
refactor: improve workout route preview handling and validation

### DIFF
--- a/api/Endpoints/WorkoutsEndpoints.cs
+++ b/api/Endpoints/WorkoutsEndpoints.cs
@@ -433,23 +433,32 @@ public static class WorkoutsEndpoints
             return new Dictionary<Guid, (string? PreviewGeoJson, string? FallbackRouteGeoJson)>();
         }
 
-        // COALESCE-style: read RouteGeoJson only when preview is null or the empty-string sentinel.
-        var rows = await db.WorkoutRoutes
+        // Do not compare jsonb to '' in SQL — PostgreSQL rejects `jsonb = ''` (500 on GET /workouts).
+        // Load previews first, then the full route only for rows that still need a fallback.
+        var previews = await db.WorkoutRoutes
             .AsNoTracking()
             .Where(r => workoutIds.Contains(r.WorkoutId))
-            .Select(r => new
-            {
-                r.WorkoutId,
-                r.PreviewGeoJson,
-                FallbackRouteGeoJson = r.PreviewGeoJson == null || r.PreviewGeoJson == ""
-                    ? r.RouteGeoJson
-                    : null
-            })
+            .Select(r => new { r.WorkoutId, r.PreviewGeoJson })
             .ToListAsync();
 
-        return rows.ToDictionary(
+        var fallbackIds = previews
+            .Where(r => TrackGeometry.IsUnusableListPreview(r.PreviewGeoJson))
+            .Select(r => r.WorkoutId)
+            .ToList();
+
+        Dictionary<Guid, string?> fallbacks = new();
+        if (fallbackIds.Count > 0)
+        {
+            fallbacks = await db.WorkoutRoutes
+                .AsNoTracking()
+                .Where(r => fallbackIds.Contains(r.WorkoutId))
+                .Select(r => new { r.WorkoutId, r.RouteGeoJson })
+                .ToDictionaryAsync(r => r.WorkoutId, r => (string?)r.RouteGeoJson);
+        }
+
+        return previews.ToDictionary(
             r => r.WorkoutId,
-            r => (r.PreviewGeoJson, r.FallbackRouteGeoJson));
+            r => (r.PreviewGeoJson, fallbacks.GetValueOrDefault(r.WorkoutId)));
     }
 
     private static async Task<Dictionary<Guid, List<object>>> LoadListMediaAsync(
@@ -475,7 +484,9 @@ public static class WorkoutsEndpoints
         Guid workoutId,
         ILogger logger)
     {
-        var json = !string.IsNullOrEmpty(previewGeoJson) ? previewGeoJson : fallbackRouteGeoJson;
+        var json = TrackGeometry.IsUnusableListPreview(previewGeoJson)
+            ? fallbackRouteGeoJson
+            : previewGeoJson;
         if (string.IsNullOrEmpty(json))
         {
             return null;

--- a/api/Models/WorkoutRoute.cs
+++ b/api/Models/WorkoutRoute.cs
@@ -17,7 +17,7 @@ public class WorkoutRoute
 
     /// <summary>
     /// Douglas-Peucker preview of <see cref="RouteGeoJson"/> (≤ 100 points).
-    /// Null means not yet computed; empty string is a sentinel for empty or unparseable source geometry.
+    /// Null means not yet computed; <c>[]</c> is a sentinel for empty or unparseable source geometry.
     /// </summary>
     [Column(TypeName = "jsonb")]
     public string? PreviewGeoJson { get; set; }

--- a/api/Services/RoutePreviewBackfillService.cs
+++ b/api/Services/RoutePreviewBackfillService.cs
@@ -5,7 +5,7 @@ namespace Tempo.Api.Services;
 
 /// <summary>
 /// Fills <c>WorkoutRoutes.PreviewGeoJson</c> for rows that still have a null preview.
-/// Idempotent: sentinel empty-string previews are left alone; a fully backfilled database is one count query.
+/// Idempotent: sentinel (<c>[]</c>) previews are left alone; a fully backfilled database is one count query.
 /// </summary>
 public class RoutePreviewBackfillService
 {

--- a/api/Services/TrackGeometry.cs
+++ b/api/Services/TrackGeometry.cs
@@ -22,7 +22,18 @@ public sealed class TrackGeometryResult
 public class TrackGeometry
 {
     public const int RoutePreviewMaxPoints = 100;
-    public const string EmptyRoutePreviewSentinel = "";
+
+    /// <summary>
+    /// Valid JSON stored when source geometry is empty or unparseable.
+    /// Must be legal jsonb — an empty string is rejected by PostgreSQL.
+    /// </summary>
+    public const string EmptyRoutePreviewSentinel = "[]";
+
+    /// <summary>
+    /// True when the list endpoint should fall back to the full route (or omit the preview).
+    /// </summary>
+    public static bool IsUnusableListPreview(string? previewGeoJson) =>
+        string.IsNullOrWhiteSpace(previewGeoJson) || previewGeoJson == EmptyRoutePreviewSentinel;
 
     private const int PreviewToleranceSearchIterations = 40;
     private const double PreviewToleranceStartMeters = 1.0;

--- a/api/Tempo.Api.Tests/Services/RoutePreviewTests.cs
+++ b/api/Tempo.Api.Tests/Services/RoutePreviewTests.cs
@@ -70,6 +70,22 @@ public class RoutePreviewTests
         TrackGeometry.BuildRoutePreviewGeoJson(geoJson).Should().Be(TrackGeometry.EmptyRoutePreviewSentinel);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("[]")]
+    public void IsUnusableListPreview_IsTrue_ForMissingOrSentinel(string? preview)
+    {
+        TrackGeometry.IsUnusableListPreview(preview).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsUnusableListPreview_IsFalse_ForLineString()
+    {
+        TrackGeometry.IsUnusableListPreview(LineStringWithCount(3)).Should().BeFalse();
+    }
+
     private static string LineStringWithCount(int count, bool wavy = false)
     {
         var coordinates = new List<double[]>(count);


### PR DESCRIPTION
- Updated the `WorkoutsEndpoints` to load route previews more efficiently, implementing fallback logic for unusable previews.
- Modified the `WorkoutRoute` model documentation to clarify the sentinel value for `PreviewGeoJson`.
- Enhanced the `TrackGeometry` service to define a valid JSON sentinel for empty or unparseable source geometry.
- Added unit tests for the `IsUnusableListPreview` method to ensure correct behavior for various input scenarios.