### PR TITLE
refactor: order splits by index in workout endpoints and query service

### DIFF
--- a/api/Endpoints/WorkoutsEndpoints.cs
+++ b/api/Endpoints/WorkoutsEndpoints.cs
@@ -1159,7 +1159,7 @@ public static class WorkoutsEndpoints
             }
 
             // Map splits
-            var splits = workout.Splits.Select(s => new
+            var splits = workout.Splits.OrderBy(s => s.Idx).Select(s => new
             {
                 idx = s.Idx,
                 distanceM = s.DistanceM,
@@ -1302,7 +1302,7 @@ public static class WorkoutsEndpoints
         }
 
         // Map splits
-        var splits = workout.Splits.Select(s => new
+        var splits = workout.Splits.OrderBy(s => s.Idx).Select(s => new
         {
             idx = s.Idx,
             distanceM = s.DistanceM,

--- a/api/Services/WorkoutQueryService.cs
+++ b/api/Services/WorkoutQueryService.cs
@@ -119,7 +119,7 @@ public static class WorkoutQueryService
             ShoeId = w.ShoeId,
             Shoe = w.Shoe,
             Route = w.Route,
-            Splits = w.Splits
+            Splits = w.Splits.OrderBy(s => s.Idx).ToList()
         });
     }
 

--- a/api/Tempo.Api.Tests/IntegrationTests/WorkoutDetailsUpdateDeleteTests.cs
+++ b/api/Tempo.Api.Tests/IntegrationTests/WorkoutDetailsUpdateDeleteTests.cs
@@ -140,6 +140,42 @@ public class WorkoutDetailsUpdateDeleteTests : IClassFixture<TempoWebApplication
     }
 
     [Fact]
+    public async Task GetWorkout_ReturnsSplitsOrderedByIdx_WhenInsertedOutOfOrder()
+    {
+        await EnsureCleanDatabaseAsync();
+        var client = await TestHttpClientFactory.CreateAuthenticatedClientAsync(_factory);
+
+        Workout workout;
+        using (var scope = _factory.Server.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TempoDbContext>();
+            workout = await TestDataSeeder.SeedWorkoutAsync(db, name: "Out-of-order Splits");
+
+            // Insert out of Idx order so heap/insertion order would fail the assertion
+            foreach (var idx in new[] { 2, 0, 1 })
+            {
+                db.WorkoutSplits.Add(new WorkoutSplit
+                {
+                    WorkoutId = workout.Id,
+                    Idx = idx,
+                    DistanceM = 1000,
+                    DurationS = 360 + idx,
+                    PaceS = 360
+                });
+            }
+            await db.SaveChangesAsync();
+        }
+
+        var response = await client.GetAsync($"/workouts/{workout.Id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<WorkoutDetailResponse>();
+        result.Should().NotBeNull();
+        result!.Splits.Should().HaveCount(3);
+        result.Splits.Select(s => s.Idx).Should().Equal(0, 1, 2);
+    }
+
+    [Fact]
     public async Task GetWorkout_Returns404_WhenWorkoutNotFound()
     {
         // Arrange

--- a/api/Tempo.Api.Tests/Services/WorkoutQueryServiceTests.cs
+++ b/api/Tempo.Api.Tests/Services/WorkoutQueryServiceTests.cs
@@ -366,6 +366,45 @@ public class WorkoutQueryServiceTests : IDisposable
         sql.Should().Contain("RawHealthKitData");
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task QueryDetail_ReturnsSplitsOrderedByIdx_WhenInsertedOutOfOrder(bool includeRaw)
+    {
+        var workout = new Workout
+        {
+            StartedAt = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+            DistanceM = 5000,
+            DurationS = 1800,
+            AvgPaceS = 360,
+            Source = "test",
+            CreatedAt = DateTime.UtcNow
+        };
+        _db.Workouts.Add(workout);
+        await _db.SaveChangesAsync();
+
+        // Insert out of Idx order so heap/insertion order would fail the assertion
+        foreach (var idx in new[] { 2, 0, 1 })
+        {
+            _db.WorkoutSplits.Add(new WorkoutSplit
+            {
+                WorkoutId = workout.Id,
+                Idx = idx,
+                DistanceM = 1000,
+                DurationS = 360 + idx,
+                PaceS = 360
+            });
+        }
+        await _db.SaveChangesAsync();
+
+        var result = await WorkoutQueryService.QueryDetail(_db, workout.Id, includeRaw)
+            .FirstOrDefaultAsync();
+
+        result.Should().NotBeNull();
+        result!.Splits.Should().HaveCount(3);
+        result.Splits.Select(s => s.Idx).Should().Equal(0, 1, 2);
+    }
+
     [Fact]
     public async Task QueryListPage_ProjectsSplitsCountWithoutLoadingSplitRows()
     {


### PR DESCRIPTION
- Updated the `WorkoutsEndpoints` to order splits by their index when mapping.
- Modified the `WorkoutQueryService` to ensure splits are returned in order by index.
- Added integration and service tests to verify that splits are correctly ordered when inserted out of order.